### PR TITLE
Fix infinite loop on architectures where char is unsigned by default

### DIFF
--- a/src/sagan.c
+++ b/src/sagan.c
@@ -191,7 +191,7 @@ int main(int argc, char **argv)
 
     char syslogstring[MAX_SYSLOGMSG];
 
-    char c;
+    signed char c;
     char *tok;
     int rc=0;
 


### PR DESCRIPTION
For more information see [ARM FAQs](http://www.arm.linux.org.uk/docs/faqs/signedchar.php)

Sagan runs quite well on ARM architecture with that fix. 

Tested under `Linux alarm 3.10.17-5-ARCH #1 SMP Sat Jan 3 00:15:42 MST 2015 armv7l GNU/Linux`