### PR TITLE
Fix missing preprocessor guard for setting config sagan_fifo_size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+
+# after configure
+config.log
+Makefile
+config.h
+config.status
+src/.deps/
+src/Makefile
+
+# after make
+*.o
+src/sagan
+

--- a/src/sagan-config.c
+++ b/src/sagan-config.c
@@ -123,8 +123,9 @@ void Load_Config( void )
     config->sagan_fifo[0] = '\0';
     config->sagan_host[0] = '\0';
     config->sagan_port = 514;
-
+#if defined(F_GETPIPE_SZ) && defined(F_SETPIPE_SZ)
     config->sagan_fifo_size = MAX_FIFO_SIZE;
+#endif
 
     if ( config->sagan_fifo_flag != 1 )
         {


### PR DESCRIPTION
Two cases:
1. no gitignore file - ignoring generated files from configure and make command - you should also remove files from index: Makefile config.h config.status
2. On OS with kernel older than 2.6.35 (like Centos 6) there is no e.g. F_SETPIPE_SZ defined. In header file there is preprocessor guard for config->sagan_fifo_size, but in function Load_Config doesn't. In consequence it doesn't compile.

