### PR TITLE
fix a crash case when sagan user is not defined

### DIFF
--- a/src/sagan-util.c
+++ b/src/sagan-util.c
@@ -774,6 +774,11 @@ void Sagan_Open_Log_File( sbool state, int type )
     int ret;
 
     pw = getpwnam(config->sagan_runas);
+    if( pw == NULL)
+        {
+	    fprintf(stderr, "[E] [%s, line %d] Invalid user %s (use -u option to set a user)\n", __FILE__, __LINE__, config->sagan_runas);
+	    exit(1);
+        }
 
     if ( type == SAGAN_LOG || type == ALL_LOGS )
         {


### PR DESCRIPTION
we now display a nice message inviting the user to set
a valid user.