### PR TITLE
Check fork syscall return value. Log it if we got an error

### DIFF
--- a/src/output-plugins/sagan-external.c
+++ b/src/output-plugins/sagan-external.c
@@ -129,10 +129,11 @@ Syslog Priority:%s\n\
             Sagan_Log(S_ERROR, "[%s, line %d] Cannot create output pipe!", __FILE__, __LINE__);
         }
 
-
-    if (( pid = fork()) == 0 )
+    pid=fork();
+    if ( pid < 0 ) {
+            Sagan_Log(S_ERROR, "[%s, line %d] Cannot create external program process", __FILE__, __LINE__);
+    } else if ( pid == 0 )
         {
-
             /* Causes problems with alert.log */
 
             close(0);


### PR DESCRIPTION
Sometimes i got an error in the fork syscall (ENOMEM) because the server doesn't have enough memory. Because sagan doesn't check the error code i needed to strace it to find the issue.

Sagan didn't logged the failed fork. With this patch at least we log the issue.