### PR TITLE
create the fifo if we fail to open it.

### DIFF
--- a/src/sagan.c
+++ b/src/sagan.c
@@ -788,7 +788,20 @@ int main(int argc, char **argv)
 
             if (( fd = fopen(config->sagan_fifo, "r" )) == NULL )
                 {
-                    Sagan_Log(S_ERROR, "Error opening %s. Abort!", config->sagan_fifo);
+                    /* try to create it */
+                    if (mkfifo(config->sagan_fifo, 0700) == -1)
+                        {
+                          Sagan_Log(S_ERROR, "Could not create fifo %s. Abort!", config->sagan_fifo);
+                        }
+                    else
+                        {
+                          Sagan_Log(S_NORMAL, "Fifo not found, creating it (%s).", config->sagan_fifo);
+                        }
+                    fd = fopen(config->sagan_fifo, "r");
+                    if ( fd == NULL )
+                        {
+                          Sagan_Log(S_ERROR, "Error opening %s. Abort!", config->sagan_fifo);
+                        }
                 }
 
             if ( config->sagan_is_file == 0 )


### PR DESCRIPTION
It makes it easier to deploy Sagan without creating the fifo upfront.