### PR TITLE
add the event message in syslog output mode

### DIFF
--- a/src/output-plugins/sagan-syslog.c
+++ b/src/output-plugins/sagan-syslog.c
@@ -54,7 +54,7 @@ void Sagan_Alert_Syslog( _SaganEvent *Event )
 
     /* Template to mimic Snort syslog output */
 
-    char *syslog_template = "[%lu:%s:%s] %s [Classification: %s] [Priority: %d] %s %s:%d -> %s:%d";
+    char *syslog_template = "[%lu:%s:%s] %s [Classification: %s] [Priority: %d] %s %s:%d -> %s:%d - %s";
 
     if ( Event->ip_proto != 1 || Event->ip_proto != 6 || Event->ip_proto != 17 )
         {
@@ -76,7 +76,7 @@ void Sagan_Alert_Syslog( _SaganEvent *Event )
             tmp_proto = "{UDP}";
         }
 
-    snprintf(syslog_message_output, sizeof(syslog_message_output), syslog_template, Event->generatorid, Event->sid, Event->rev, Event->f_msg, Sagan_Classtype_Lookup ( Event->class ), Event->pri, tmp_proto, Event->ip_src, Event->src_port, Event->ip_dst, Event->dst_port);
+    snprintf(syslog_message_output, sizeof(syslog_message_output), syslog_template, Event->generatorid, Event->sid, Event->rev, Event->f_msg, Sagan_Classtype_Lookup ( Event->class ), Event->pri, tmp_proto, Event->ip_src, Event->src_port, Event->ip_dst, Event->dst_port, Event->message);
 
     /* Send syslog message */
 


### PR DESCRIPTION
It makes it possible to get back to the original message that triggered
the alert. This information is available in file output but was missing
in syslog output.