### PR TITLE
New xbit features

### DIFF
--- a/src/processors/engine.c
+++ b/src/processors/engine.c
@@ -720,7 +720,7 @@ int Sagan_Engine ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, sbool dynamic_rule
                      ****************************************************************************/
 
                     if ( rulestruct[b].xbit_flag && rulestruct[b].xbit_condition_count ) {
-                        xbit_return = Sagan_Xbit_Condition(b, ip_src, ip_dst);
+                        xbit_return = Sagan_Xbit_Condition(b, ip_src, ip_dst, normalize_src_port, normalize_dst_port);
                     }
 
                     /****************************************************************************
@@ -1830,7 +1830,7 @@ int Sagan_Engine ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, sbool dynamic_rule
                                                                 }
 
                                                                 if ( rulestruct[b].xbit_flag && rulestruct[b].xbit_set_count )
-                                                                    Sagan_Xbit_Set(b, ip_src, ip_dst);
+                                                                    Sagan_Xbit_Set(b, ip_src, ip_dst, normalize_src_port, normalize_dst_port);
 
                                                                 threadid++;
 

--- a/src/rules.c
+++ b/src/rules.c
@@ -618,8 +618,8 @@ void Load_Rules( const char *ruleset )
                 arg = strtok_r(NULL, ":", &saveptrrule2);
                 tmptoken = Remove_Spaces(strtok_r(arg, ",", &saveptrrule2));
 
-                if (strcmp(tmptoken, "nounified2") && strcmp(tmptoken, "noalert") && strcmp(tmptoken, "set") && strcmp(tmptoken, "unset") && strcmp(tmptoken, "isset") && strcmp(tmptoken, "isnotset")) {
-                    Sagan_Log(S_ERROR, "[%s, line %d] Expected 'nounified2', 'noalert', 'set', 'unset', 'isnotset' or 'isset' but got '%s' at line %d in %s", __FILE__, __LINE__, tmptoken, linecount, ruleset_fullname);
+                if (strcmp(tmptoken, "nounified2") && strcmp(tmptoken, "noalert") && strcmp(tmptoken, "set") && strcmp(tmptoken, "unset") && strcmp(tmptoken, "isset") && strcmp(tmptoken, "isnotset") && strcmp(tmptoken, "set_srcport") && strcmp(tmptoken, "set_dstport") && strcmp(tmptoken, "set_ports")) {
+                    Sagan_Log(S_ERROR, "[%s, line %d] Expected 'nounified2', 'noalert', 'set', 'unset', 'isnotset' or 'isset' but got '%s' at line %d in %s", __FILE__, __LINE__, tmptoken, linecount, ruleset);
                 }
 
                 if (!strcmp(tmptoken, "noalert")) {
@@ -758,6 +758,84 @@ void Load_Rules( const char *ruleset )
                     }
 
                     xbit_count++;
+
+                }
+
+                /* SET_SRCPORT */
+
+                if (!strcmp(tmptoken, "set_srcport")) {
+                    tmptoken = Remove_Spaces(strtok_r(NULL, ",", &saveptrrule2));
+
+                    if ( tmptoken == NULL ) {
+                        Sagan_Log(S_ERROR, "[%s, line %d] Expected xbit name at line %d in %s", __FILE__, __LINE__, linecount, ruleset_fullname);
+                    }
+
+                    rulestruct[counters->rulecount].xbit_flag = 1; 				/* We have xbit in the rule! */
+                    rulestruct[counters->rulecount].xbit_set_count++;
+                    rulestruct[counters->rulecount].xbit_type[xbit_count]  = 5;		/* set_srcport */
+
+                    strlcpy(rulestruct[counters->rulecount].xbit_name[xbit_count], tmptoken, sizeof(rulestruct[counters->rulecount].xbit_name[xbit_count]));
+
+                    rulestruct[counters->rulecount].xbit_timeout[xbit_count] = atoi(strtok_r(NULL, ",", &saveptrrule2));
+
+                    if ( rulestruct[counters->rulecount].xbit_timeout[xbit_count] == 0 ) {
+                        Sagan_Log(S_ERROR, "[%s, line %d] Expected xbit valid expire time for \"set\" at line %d in %s", __FILE__, __LINE__, linecount, ruleset_fullname);
+                    }
+
+                    xbit_count++;
+                    counters->xbit_total_counter++;
+
+                }
+
+                /* SET_DSTPORT */
+
+                if (!strcmp(tmptoken, "set_dstport")) {
+                    tmptoken = Remove_Spaces(strtok_r(NULL, ",", &saveptrrule2));
+
+                    if ( tmptoken == NULL ) {
+                        Sagan_Log(S_ERROR, "[%s, line %d] Expected xbit name at line %d in %s", __FILE__, __LINE__, linecount, ruleset);
+                    }
+
+                    rulestruct[counters->rulecount].xbit_flag = 1; 				/* We have xbit in the rule! */
+                    rulestruct[counters->rulecount].xbit_set_count++;
+                    rulestruct[counters->rulecount].xbit_type[xbit_count]  = 6;		/* set_dstport */
+
+                    strlcpy(rulestruct[counters->rulecount].xbit_name[xbit_count], tmptoken, sizeof(rulestruct[counters->rulecount].xbit_name[xbit_count]));
+
+                    rulestruct[counters->rulecount].xbit_timeout[xbit_count] = atoi(strtok_r(NULL, ",", &saveptrrule2));
+
+                    if ( rulestruct[counters->rulecount].xbit_timeout[xbit_count] == 0 ) {
+                        Sagan_Log(S_ERROR, "[%s, line %d] Expected xbit valid expire time for \"set\" at line %d in %s", __FILE__, __LINE__, linecount, ruleset);
+                    }
+
+                    xbit_count++;
+                    counters->xbit_total_counter++;
+
+                }
+
+                /* SET_PORTS */
+
+                if (!strcmp(tmptoken, "set_ports")) {
+                    tmptoken = Remove_Spaces(strtok_r(NULL, ",", &saveptrrule2));
+
+                    if ( tmptoken == NULL ) {
+                        Sagan_Log(S_ERROR, "[%s, line %d] Expected xbit name at line %d in %s", __FILE__, __LINE__, linecount, ruleset);
+                    }
+
+                    rulestruct[counters->rulecount].xbit_flag = 1; 				/* We have xbit in the rule! */
+                    rulestruct[counters->rulecount].xbit_set_count++;
+                    rulestruct[counters->rulecount].xbit_type[xbit_count]  = 7;		/* set_ports */
+
+                    strlcpy(rulestruct[counters->rulecount].xbit_name[xbit_count], tmptoken, sizeof(rulestruct[counters->rulecount].xbit_name[xbit_count]));
+
+                    rulestruct[counters->rulecount].xbit_timeout[xbit_count] = atoi(strtok_r(NULL, ",", &saveptrrule2));
+
+                    if ( rulestruct[counters->rulecount].xbit_timeout[xbit_count] == 0 ) {
+                        Sagan_Log(S_ERROR, "[%s, line %d] Expected xbit valid expire time for \"set\" at line %d in %s", __FILE__, __LINE__, linecount, ruleset);
+                    }
+
+                    xbit_count++;
+                    counters->xbit_total_counter++;
 
                 }
 

--- a/src/rules.h
+++ b/src/rules.h
@@ -118,7 +118,7 @@ struct _Rule_Struct {
     sbool xbit_noalert;                         /* Do we want to suppress "alerts" from xbits in ALL output plugins? */
     sbool xbit_nounified2;                      /* Do we want to suppress "unified2" from xbits in unified2 output */
 
-    int xbit_type[MAX_XBITS];                   /* 1 == set, 2 == unset,  3 == isset, 4 == isnotset */
+    int xbit_type[MAX_XBITS];                   /* 1 == set, 2 == unset,  3 == isset, 4 == isnotset, 5 == set_srcport, 6 == set_dstport, 7 == set_ports */
     int xbit_direction[MAX_XBITS];              /* 0 == none, 1 == both, 2 == by_src, 3 == by_dst */
     int xbit_timeout[MAX_XBITS];                /* How long a xbit is to stay alive (seconds) */
     char xbit_name[MAX_XBITS][64];              /* Name of the xbit */

--- a/src/xbit.c
+++ b/src/xbit.c
@@ -60,7 +60,7 @@ struct _Sagan_IPC_Xbit *xbit_ipc;
  * rule condition is tested here and returned.
  *****************************************************************************/
 
-int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char )
+int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char, int src_port, int dst_port )
 {
 
     time_t t;
@@ -126,6 +126,8 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                             }
 
                             xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
                         }
 
                         /* direction: both */
@@ -141,6 +143,8 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                             }
 
                             xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
                         }
 
                         /* direction: by_src */
@@ -155,6 +159,8 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                             }
 
                             xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
                         }
 
                         /* direction: by_dst */
@@ -169,6 +175,8 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                             }
 
                             xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
                         }
 
                         /* direction: reverse */
@@ -183,12 +191,151 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                             }
 
                             xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
                         }
 
-                    } /* End of strcmp xbit_name & xbit_state = true */
+                        /* direction: src_xbitdst */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 5 &&
+                             xbit_ipc[a].ip_dst == ip_src )
+
+                        {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"isset\" xbit \"%s\" (direction: \"src_xbitdst\"). (%s -> any)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char);
+                            }
+
+                            xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
+                        }
+
+                        /* direction: dst_xbitsrc */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 6 &&
+                             xbit_ipc[a].ip_src == ip_dst )
+
+                        {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"isset\" xbit \"%s\" (direction: \"dst_xbitsrc\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char);
+                            }
+
+                            xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
+                        }
+
+                        /* direction: both_p */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 7 &&
+                             xbit_ipc[a].ip_src == ip_src &&
+                             xbit_ipc[a].ip_dst == ip_dst &&
+							 xbit_ipc[a].src_port == src_port &&
+							 xbit_ipc[a].dst_port == dst_port )
+
+                        {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"isset\" xbit \"%s\" (direction: \"both_p\"). (%s -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char, ip_dst_char);
+                            }
+
+                            xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
+                        }
+
+                        /* direction: by_src_p */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 8 &&
+                             xbit_ipc[a].ip_src == ip_src &&
+							 xbit_ipc[a].src_port == src_port )
+
+                        {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"isset\" xbit \"%s\" (direction: \"by_src_p\"). (%s -> any)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char);
+                            }
+
+                            xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
+                        }
+
+                        /* direction: by_dst_p */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 9 &&
+                             xbit_ipc[a].ip_dst == ip_dst &&
+							 xbit_ipc[a].dst_port == dst_port )
+
+                        {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"isset\" xbit \"%s\" (direction: \"by_dst_p\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char);
+                            }
+
+                            xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
+                        }
+
+                        /* direction: reverse_p */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 10 &&
+                             xbit_ipc[a].ip_src == ip_dst &&
+                             xbit_ipc[a].ip_dst == ip_src &&
+							 xbit_ipc[a].src_port == dst_port &&
+							 xbit_ipc[a].dst_port == src_port )
+
+                        {
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"isset\" xbit \"%s\" (direction: \"reverse_p\"). (%s -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char, ip_src_char);
+                            }
+
+                            xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
+                        }
+
+                        /* direction: src_xbitdst_p */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 11 &&
+                             xbit_ipc[a].ip_dst == ip_src &&
+							 xbit_ipc[a].dst_port == src_port )
+
+                        {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"isset\" xbit \"%s\" (direction: \"src_xbitdst_p\"). (%s -> any)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char);
+                            }
+
+                            xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
+                        }
+
+                        /* direction: dst_xbitsrc */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 12 &&
+                             xbit_ipc[a].ip_src == ip_dst &&
+							 xbit_ipc[a].src_port == dst_port )
+
+                        {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"isset\" xbit \"%s\" (direction: \"dst_xbitsrc_p\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char);
+                            }
+
+                            xbit_total_match++;
+                            a = counters_ipc->xbit_count;
+                            break;
+                        }
+
+                    } /* End of strcmp xbit_name & xbit_state = 1 */
 
 
-                    if ( and_or == true) {
+                    if ( and_or == 1) {
                         tmp_xbit_name = strtok_r(NULL, "|", &tok);
                     } else {
                         tmp_xbit_name = strtok_r(NULL, "&", &tok);
@@ -237,6 +384,8 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                                 }
 
                                 xbit_total_match++;
+                                a = counters_ipc->xbit_count;
+                                break;
                             }
 
                             /* direction: both */
@@ -252,6 +401,8 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                                     }
 
                                     xbit_total_match++;
+                                    a = counters_ipc->xbit_count;
+                                    break;
                                 }
                             }
 
@@ -266,6 +417,8 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                                     }
 
                                     xbit_total_match++;
+                                    a = counters_ipc->xbit_count;
+                                    break;
                                 }
                             }
 
@@ -280,6 +433,8 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                                     }
 
                                     xbit_total_match++;
+                                    a = counters_ipc->xbit_count;
+                                    break;
                                 }
                             }
 
@@ -295,14 +450,157 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                                     }
 
                                     xbit_total_match++;
+                                    a = counters_ipc->xbit_count;
+                                    break;
                                 }
                             }
 
-                        } /* End xbit_state == false */
+                            /* direction: src_xbitdst */
+
+                            if ( rulestruct[rule_position].xbit_direction[i] == 5 ) {
+
+                                if ( xbit_ipc[a].ip_dst == ip_src ) {
+
+                                    if ( debug->debugxbit) {
+                                        Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"src_xbitdst\"). (%s -> any)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char);
+                                    }
+
+                                    xbit_total_match++;
+                                    a = counters_ipc->xbit_count;
+                                    break;
+                                }
+                            }
+
+                            /* direction: dst_xbitsrc */
+
+                            if ( rulestruct[rule_position].xbit_direction[i] == 6 ) {
+
+                                if ( xbit_ipc[a].ip_src == ip_dst ) {
+
+                                    if ( debug->debugxbit) {
+                                        Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"dst_xbitsrc\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char);
+                                    }
+
+                                    xbit_total_match++;
+                                    a = counters_ipc->xbit_count;
+                                    break;
+                                }
+                            }
+
+                            /* direction: both_p */
+
+                            if ( rulestruct[rule_position].xbit_direction[i] == 7 ) {
+
+
+                                if ( xbit_ipc[a].ip_src == ip_src &&
+                                     xbit_ipc[a].ip_dst == ip_dst &&
+									 xbit_ipc[a].src_port == src_port &&
+									 xbit_ipc[a].dst_port == dst_port ) {
+
+                                    if ( debug->debugxbit) {
+                                        Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"both_y\"). (%s -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char, ip_dst_char);
+                                    }
+
+                                    xbit_total_match++;
+                                    a = counters_ipc->xbit_count;
+                                    break;
+                                }
+                            }
+
+                            /* direction: by_src_p */
+
+                            if ( rulestruct[rule_position].xbit_direction[i] == 8 ) {
+
+                                if ( xbit_ipc[a].ip_src == ip_src &&
+           							 xbit_ipc[a].src_port == src_port ) {
+
+                                    if ( debug->debugxbit) {
+                                        Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"by_src_p\"). (%s -> any)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char);
+                                    }
+
+                                    xbit_total_match++;
+                                    a = counters_ipc->xbit_count;
+                                    break;
+                                }
+                            }
+
+                            /* direction: by_dst_p */
+
+                            if ( rulestruct[rule_position].xbit_direction[i] == 9 ) {
+
+                                if ( xbit_ipc[a].ip_dst == ip_dst &&
+           							 xbit_ipc[a].dst_port == dst_port ) {
+
+                                    if ( debug->debugxbit) {
+                                        Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"by_dst_p\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char);
+                                    }
+
+                                    xbit_total_match++;
+                                    a = counters_ipc->xbit_count;
+                                    break;
+                                }
+                            }
+
+                            /* direction: reverse_p */
+
+                            if ( rulestruct[rule_position].xbit_direction[i] == 10 ) {
+
+                                if ( xbit_ipc[a].ip_src == ip_dst &&
+                                     xbit_ipc[a].ip_dst == ip_src &&
+									 xbit_ipc[a].src_port == dst_port &&
+									 xbit_ipc[a].dst_port == src_port) {
+
+                                    if ( debug->debugxbit) {
+                                        Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"reverse_p\"). (%s -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char, ip_src_char);
+                                    }
+
+                                    xbit_total_match++;
+                                    a = counters_ipc->xbit_count;
+                                    break;
+                                }
+                            }
+
+                            /* direction: src_xbitdst_p */
+
+                            if ( rulestruct[rule_position].xbit_direction[i] == 11 ) {
+
+                                if ( xbit_ipc[a].ip_dst == ip_src &&
+           							 xbit_ipc[a].dst_port == src_port ) {
+
+                                    if ( debug->debugxbit) {
+                                        Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"src_xbitdst_p\"). (%s -> any)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char);
+                                    }
+
+                                    xbit_total_match++;
+                                    a = counters_ipc->xbit_count;
+                                    break;
+                                }
+                            }
+
+                            /* direction: dst_xbitsrc_p */
+
+                            if ( rulestruct[rule_position].xbit_direction[i] == 12 ) {
+
+                                if ( xbit_ipc[a].ip_src == ip_dst &&
+           							 xbit_ipc[a].src_port == dst_port ) {
+
+                                    if ( debug->debugxbit) {
+                                        Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"dst_xbitsrc_p\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char);
+                                    }
+
+                                    xbit_total_match++;
+                                    a = counters_ipc->xbit_count;
+                                    break;
+                                }
+                            }
+
+
+
+                        } /* End xbit_state == 0 */
 
                     } /* End of strcmp xbit_name */
 
-                    if ( and_or == true ) {
+                    if ( and_or == true) {
                         tmp_xbit_name = strtok_r(NULL, "|", &tok);
                     } else {
                         tmp_xbit_name = strtok_r(NULL, "&", &tok);
@@ -356,7 +654,7 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
  * "unset" happen here.
  *****************************************************************************/
 
-void Sagan_Xbit_Set(int rule_position, char *ip_src_char, char *ip_dst_char )
+void Sagan_Xbit_Set(int rule_position, char *ip_src_char, char *ip_dst_char, int src_port, int dst_port )
 {
 
     int i = 0;
@@ -530,6 +828,190 @@ void Sagan_Xbit_Set(int rule_position, char *ip_src_char, char *ip_dst_char )
                             xbit_unset_match = 1;
 
                         }
+
+                        /* direction: src_xbitdst */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 5 &&
+                             xbit_ipc[a].ip_dst == ip_src ) {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"unset\" xbit \"%s\" (direction: \"src_xbitdst\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char);
+                            }
+
+                            Sagan_File_Lock(config->shm_xbit);
+                            pthread_mutex_lock(&Xbit_Mutex);
+
+                            xbit_ipc[a].xbit_state = 0;
+
+                            pthread_mutex_unlock(&Xbit_Mutex);
+                            Sagan_File_Unlock(config->shm_xbit);
+
+                            xbit_unset_match = 1;
+
+                        }
+
+                        /* direction: dst_xbitsrc */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 6 &&
+                             xbit_ipc[a].ip_src == ip_dst ) {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"unset\" xbit \"%s\" (direction: \"dst_xbitsrc\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char);
+                            }
+
+                            Sagan_File_Lock(config->shm_xbit);
+                            pthread_mutex_lock(&Xbit_Mutex);
+
+                            xbit_ipc[a].xbit_state = 0;
+
+                            pthread_mutex_unlock(&Xbit_Mutex);
+                            Sagan_File_Unlock(config->shm_xbit);
+
+                            xbit_unset_match = 1;
+
+                        }
+
+                        /* direction: both_p */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 7 &&
+                             xbit_ipc[a].ip_src == ip_src &&
+                             xbit_ipc[a].ip_dst == ip_dst &&
+							 xbit_ipc[a].src_port == src_port &&
+							 xbit_ipc[a].dst_port == dst_port ) {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"unset\" xbit \"%s\" (direction: \"both_p\"). (%s -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char, ip_dst_char);
+                            }
+
+                            Sagan_File_Lock(config->shm_xbit);
+                            pthread_mutex_lock(&Xbit_Mutex);
+
+                            xbit_ipc[a].xbit_state = 0;
+
+                            pthread_mutex_unlock(&Xbit_Mutex);
+                            Sagan_File_Unlock(config->shm_xbit);
+
+                            xbit_unset_match = 1;
+
+                        }
+
+                        /* direction: by_src_p */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 8 &&
+                             xbit_ipc[a].ip_src == ip_src &&
+							 xbit_ipc[a].src_port == src_port )
+
+                        {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"unset\" xbit \"%s\" (direction: \"by_src_p\"). (%s -> any)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char);
+                            }
+
+                            Sagan_File_Lock(config->shm_xbit);
+                            pthread_mutex_lock(&Xbit_Mutex);
+
+                            xbit_ipc[a].xbit_state = 0;
+
+                            pthread_mutex_unlock(&Xbit_Mutex);
+                            Sagan_File_Unlock(config->shm_xbit);
+
+                            xbit_unset_match = 1;
+
+                        }
+
+
+                        /* direction: by_dst_p */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 9 &&
+                             xbit_ipc[a].ip_dst == ip_dst &&
+							 xbit_ipc[a].dst_port == dst_port ) {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"unset\" xbit \"%s\" (direction: \"by_dst\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char);
+                            }
+
+                            Sagan_File_Lock(config->shm_xbit);
+                            pthread_mutex_lock(&Xbit_Mutex);
+
+                            xbit_ipc[a].xbit_state = 0;
+
+                            pthread_mutex_unlock(&Xbit_Mutex);
+                            Sagan_File_Unlock(config->shm_xbit);
+
+                            xbit_unset_match = 1;
+
+                        }
+
+                        /* direction: reverse_p */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 10 &&
+                             xbit_ipc[a].ip_dst == ip_src &&
+                             xbit_ipc[a].ip_src == ip_dst &&
+							 xbit_ipc[a].src_port == dst_port &&
+							 xbit_ipc[a].dst_port == src_port )
+
+                        {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"unset\" xbit \"%s\" (direction: \"reverse_p\"). (%s -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char, ip_src_char);
+                            }
+
+                            Sagan_File_Lock(config->shm_xbit);
+                            pthread_mutex_lock(&Xbit_Mutex);
+
+                            xbit_ipc[a].xbit_state = 0;
+
+                            pthread_mutex_unlock(&Xbit_Mutex);
+                            Sagan_File_Unlock(config->shm_xbit);
+
+                            xbit_unset_match = 1;
+
+                        }
+
+                        /* direction: src_xbitdst_p */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 11 &&
+                             xbit_ipc[a].ip_dst == ip_src &&
+							 xbit_ipc[a].dst_port == src_port ) {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"unset\" xbit \"%s\" (direction: \"src_xbitdst_p\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char);
+                            }
+
+                            Sagan_File_Lock(config->shm_xbit);
+                            pthread_mutex_lock(&Xbit_Mutex);
+
+                            xbit_ipc[a].xbit_state = 0;
+
+                            pthread_mutex_unlock(&Xbit_Mutex);
+                            Sagan_File_Unlock(config->shm_xbit);
+
+                            xbit_unset_match = 1;
+
+                        }
+
+                        /* direction: dst_xbitsrc_p */
+
+                        if ( rulestruct[rule_position].xbit_direction[i] == 12 &&
+                             xbit_ipc[a].ip_src == ip_dst &&
+							 xbit_ipc[a].src_port == dst_port ) {
+
+                            if ( debug->debugxbit) {
+                                Sagan_Log(S_DEBUG, "[%s, line %d] \"unset\" xbit \"%s\" (direction: \"dst_xbitsrc_p\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char);
+                            }
+
+                            Sagan_File_Lock(config->shm_xbit);
+                            pthread_mutex_lock(&Xbit_Mutex);
+
+                            xbit_ipc[a].xbit_state = 0;
+
+                            pthread_mutex_unlock(&Xbit_Mutex);
+                            Sagan_File_Unlock(config->shm_xbit);
+
+                            xbit_unset_match = 1;
+
+                        }
+
                     }
                 }
 
@@ -562,7 +1044,9 @@ void Sagan_Xbit_Set(int rule_position, char *ip_src_char, char *ip_dst_char )
 
                     if (!strcmp(xbit_ipc[a].xbit_name, tmp_xbit_name) &&
                         xbit_ipc[a].ip_src == ip_src &&
-                        xbit_ipc[a].ip_dst == ip_dst ) {
+                        xbit_ipc[a].ip_dst == ip_dst &&
+                        xbit_ipc[a].src_port == config->sagan_port &&
+                        xbit_ipc[a].dst_port == config->sagan_port ) {
 
                         Sagan_File_Lock(config->shm_xbit);
                         pthread_mutex_lock(&Xbit_Mutex);
@@ -596,6 +1080,8 @@ void Sagan_Xbit_Set(int rule_position, char *ip_src_char, char *ip_dst_char )
 
                     strlcpy(xbit_track[xbit_track_count].xbit_name, tmp_xbit_name, sizeof(xbit_track[xbit_track_count].xbit_name));
                     xbit_track[xbit_track_count].xbit_timeout = rulestruct[rule_position].xbit_timeout[i];
+                    xbit_track[xbit_track_count].xbit_srcport = config->sagan_port;
+                    xbit_track[xbit_track_count].xbit_dstport = config->sagan_port;
                     xbit_track_count++;
 
                 }
@@ -605,6 +1091,213 @@ void Sagan_Xbit_Set(int rule_position, char *ip_src_char, char *ip_dst_char )
             } /* While & xbits (ie - bit1&bit2) */
 
         } /* if xbit_type == 1 */
+
+        /***************************
+         *      SET_SRCPORT        *
+        ****************************/
+
+        if ( rulestruct[rule_position].xbit_type[i] == 5 ) {
+
+            xbit_match = 0;
+
+            /* Xbits & (ie - bit1&bit2) */
+
+            strlcpy(tmp, rulestruct[rule_position].xbit_name[i], sizeof(tmp));
+            tmp_xbit_name = strtok_r(tmp, "&", &tok);
+
+            while( tmp_xbit_name != NULL ) {
+
+                for (a = 0; a < counters_ipc->xbit_count; a++) {
+
+                    /* Do we have the xbit already in memory?  If so,  update the information */
+
+                    if (!strcmp(xbit_ipc[a].xbit_name, tmp_xbit_name) &&
+                        xbit_ipc[a].ip_src == ip_src &&
+                        xbit_ipc[a].ip_dst == ip_dst &&
+                        xbit_ipc[a].src_port == src_port &&
+                        xbit_ipc[a].dst_port == config->sagan_port ) {
+
+                        Sagan_File_Lock(config->shm_xbit);
+                        pthread_mutex_lock(&Xbit_Mutex);
+
+                        xbit_ipc[a].xbit_date = atol(timet);
+                        xbit_ipc[a].xbit_expire = atol(timet) + rulestruct[rule_position].xbit_timeout[i];
+                        xbit_ipc[a].xbit_state = 1;
+
+                        if ( debug->debugxbit) {
+                            Sagan_Log(S_DEBUG, "[%s, line %d] [%d] Updated via \"set_srcport\" for xbit \"%s\", [%d].  New expire time is %d (%d) [%u -> %u]. ", __FILE__, __LINE__, a, tmp_xbit_name, i, xbit_ipc[i].xbit_expire, rulestruct[rule_position].xbit_timeout[i], xbit_ipc[a].ip_src, xbit_ipc[a].ip_dst);
+                        }
+
+                        pthread_mutex_unlock(&Xbit_Mutex);
+                        Sagan_File_Unlock(config->shm_xbit);
+
+                        xbit_match = 1;
+                    }
+
+                }
+
+
+                /* If the xbit isn't in memory,  store it to be created later */
+
+                if ( xbit_match == 0 ) {
+
+                    xbit_track = ( _Sagan_Xbit_Track * ) realloc(xbit_track, (xbit_track_count+1) * sizeof(_Sagan_Xbit_Track));
+
+                    if ( xbit_track == NULL ) {
+                        Sagan_Log(S_ERROR, "[%s, line %d] Failed to reallocate memory for xbit_track. Abort!", __FILE__, __LINE__);
+                    }
+
+                    strlcpy(xbit_track[xbit_track_count].xbit_name, tmp_xbit_name, sizeof(xbit_track[xbit_track_count].xbit_name));
+                    xbit_track[xbit_track_count].xbit_timeout = rulestruct[rule_position].xbit_timeout[i];
+                    xbit_track[xbit_track_count].xbit_srcport = src_port;
+                    xbit_track[xbit_track_count].xbit_dstport = config->sagan_port;
+                    xbit_track_count++;
+
+                }
+
+                tmp_xbit_name = strtok_r(NULL, "&", &tok);
+
+            } /* While & xbits (ie - bit1&bit2) */
+
+        } /* if xbit_type == 5 */
+
+        /***************************
+         *      SET_DSTPORT        *
+        ****************************/
+
+        if ( rulestruct[rule_position].xbit_type[i] == 6 ) {
+
+            xbit_match = 0;
+
+            /* Xbits & (ie - bit1&bit2) */
+
+            strlcpy(tmp, rulestruct[rule_position].xbit_name[i], sizeof(tmp));
+            tmp_xbit_name = strtok_r(tmp, "&", &tok);
+
+            while( tmp_xbit_name != NULL ) {
+
+                for (a = 0; a < counters_ipc->xbit_count; a++) {
+
+                    /* Do we have the xbit already in memory?  If so,  update the information */
+
+                    if (!strcmp(xbit_ipc[a].xbit_name, tmp_xbit_name) &&
+                        xbit_ipc[a].ip_src == ip_src &&
+                        xbit_ipc[a].ip_dst == ip_dst &&
+                        xbit_ipc[a].src_port == config->sagan_port &&
+                        xbit_ipc[a].dst_port == dst_port ) {
+
+                        Sagan_File_Lock(config->shm_xbit);
+                        pthread_mutex_lock(&Xbit_Mutex);
+
+                        xbit_ipc[a].xbit_date = atol(timet);
+                        xbit_ipc[a].xbit_expire = atol(timet) + rulestruct[rule_position].xbit_timeout[i];
+                        xbit_ipc[a].xbit_state = 1;
+
+                        if ( debug->debugxbit) {
+                            Sagan_Log(S_DEBUG, "[%s, line %d] [%d] Updated via \"set_dstport\" for xbit \"%s\", [%d].  New expire time is %d (%d) [%u -> %u]. ", __FILE__, __LINE__, a, tmp_xbit_name, i, xbit_ipc[i].xbit_expire, rulestruct[rule_position].xbit_timeout[i], xbit_ipc[a].ip_src, xbit_ipc[a].ip_dst);
+                        }
+
+                        pthread_mutex_unlock(&Xbit_Mutex);
+                        Sagan_File_Unlock(config->shm_xbit);
+
+                        xbit_match = 1;
+                    }
+
+                }
+
+
+                /* If the xbit isn't in memory,  store it to be created later */
+
+                if ( xbit_match == 0 ) {
+
+                    xbit_track = ( _Sagan_Xbit_Track * ) realloc(xbit_track, (xbit_track_count+1) * sizeof(_Sagan_Xbit_Track));
+
+                    if ( xbit_track == NULL ) {
+                        Sagan_Log(S_ERROR, "[%s, line %d] Failed to reallocate memory for xbit_track. Abort!", __FILE__, __LINE__);
+                    }
+
+                    strlcpy(xbit_track[xbit_track_count].xbit_name, tmp_xbit_name, sizeof(xbit_track[xbit_track_count].xbit_name));
+                    xbit_track[xbit_track_count].xbit_timeout = rulestruct[rule_position].xbit_timeout[i];
+                    xbit_track[xbit_track_count].xbit_srcport = config->sagan_port;
+                    xbit_track[xbit_track_count].xbit_dstport = dst_port;
+                    xbit_track_count++;
+
+                }
+
+                tmp_xbit_name = strtok_r(NULL, "&", &tok);
+
+            } /* While & xbits (ie - bit1&bit2) */
+
+        } /* if xbit_type == 6 */
+
+        /*************************
+         *      SET_PORTS        *
+        **************************/
+
+        if ( rulestruct[rule_position].xbit_type[i] == 7 ) {
+
+            xbit_match = 0;
+
+            /* Xbits & (ie - bit1&bit2) */
+
+            strlcpy(tmp, rulestruct[rule_position].xbit_name[i], sizeof(tmp));
+            tmp_xbit_name = strtok_r(tmp, "&", &tok);
+
+            while( tmp_xbit_name != NULL ) {
+
+                for (a = 0; a < counters_ipc->xbit_count; a++) {
+
+                    /* Do we have the xbit already in memory?  If so,  update the information */
+
+                    if (!strcmp(xbit_ipc[a].xbit_name, tmp_xbit_name) &&
+                        xbit_ipc[a].ip_src == ip_src &&
+                        xbit_ipc[a].ip_dst == ip_dst &&
+                        xbit_ipc[a].src_port == src_port &&
+                        xbit_ipc[a].dst_port == dst_port ) {
+
+                        Sagan_File_Lock(config->shm_xbit);
+                        pthread_mutex_lock(&Xbit_Mutex);
+
+                        xbit_ipc[a].xbit_date = atol(timet);
+                        xbit_ipc[a].xbit_expire = atol(timet) + rulestruct[rule_position].xbit_timeout[i];
+                        xbit_ipc[a].xbit_state = 1;
+
+                        if ( debug->debugxbit) {
+                            Sagan_Log(S_DEBUG, "[%s, line %d] [%d] Updated via \"set_ports\" for xbit \"%s\", [%d].  New expire time is %d (%d) [%u -> %u]. ", __FILE__, __LINE__, a, tmp_xbit_name, i, xbit_ipc[i].xbit_expire, rulestruct[rule_position].xbit_timeout[i], xbit_ipc[a].ip_src, xbit_ipc[a].ip_dst);
+                        }
+
+                        pthread_mutex_unlock(&Xbit_Mutex);
+                        Sagan_File_Unlock(config->shm_xbit);
+
+                        xbit_match = 1;
+                    }
+
+                }
+
+
+                /* If the xbit isn't in memory,  store it to be created later */
+
+                if ( xbit_match == 0 ) {
+
+                    xbit_track = ( _Sagan_Xbit_Track * ) realloc(xbit_track, (xbit_track_count+1) * sizeof(_Sagan_Xbit_Track));
+
+                    if ( xbit_track == NULL ) {
+                        Sagan_Log(S_ERROR, "[%s, line %d] Failed to reallocate memory for xbit_track. Abort!", __FILE__, __LINE__);
+                    }
+
+                    strlcpy(xbit_track[xbit_track_count].xbit_name, tmp_xbit_name, sizeof(xbit_track[xbit_track_count].xbit_name));
+                    xbit_track[xbit_track_count].xbit_timeout = rulestruct[rule_position].xbit_timeout[i];
+                    xbit_track[xbit_track_count].xbit_srcport = src_port;
+                    xbit_track[xbit_track_count].xbit_dstport = dst_port;
+                    xbit_track_count++;
+
+                }
+
+                tmp_xbit_name = strtok_r(NULL, "&", &tok);
+
+            } /* While & xbits (ie - bit1&bit2) */
+
+        } /* if xbit_type == 7 */
 
     } /* Out of for i loop */
 
@@ -621,6 +1314,8 @@ void Sagan_Xbit_Set(int rule_position, char *ip_src_char, char *ip_dst_char )
 
                 xbit_ipc[counters_ipc->xbit_count].ip_src = ip_src;
                 xbit_ipc[counters_ipc->xbit_count].ip_dst = ip_dst;
+                xbit_ipc[counters_ipc->xbit_count].src_port = xbit_track[i].xbit_srcport;
+                xbit_ipc[counters_ipc->xbit_count].dst_port = xbit_track[i].xbit_dstport;
                 xbit_ipc[counters_ipc->xbit_count].xbit_date = atol(timet);
                 xbit_ipc[counters_ipc->xbit_count].xbit_expire = atol(timet) + xbit_track[i].xbit_timeout;
                 xbit_ipc[counters_ipc->xbit_count].xbit_state = true;
@@ -632,7 +1327,7 @@ void Sagan_Xbit_Set(int rule_position, char *ip_src_char, char *ip_dst_char )
                 Sagan_File_Unlock(config->shm_xbit);
 
                 if ( debug->debugxbit) {
-                    Sagan_Log(S_DEBUG, "[%s, line %d] [%d] Created xbit \"%s\" via \"set\" [%s -> %s],", __FILE__, __LINE__, counters_ipc->xbit_count, xbit_ipc[counters_ipc->xbit_count].xbit_name, ip_src_char, ip_dst_char);
+                    Sagan_Log(S_DEBUG, "[%s, line %d] [%d] Created xbit \"%s\" via \"set, set_srcport, set_dstport, or set_ports\" [%s:%d -> %s:%d],", __FILE__, __LINE__, counters_ipc->xbit_count, xbit_ipc[counters_ipc->xbit_count].xbit_name, ip_src_char, xbit_track[i].xbit_srcport, ip_dst_char, xbit_track[i].xbit_dstport);
                 }
 
                 Sagan_File_Lock(config->shm_counters);
@@ -680,7 +1375,39 @@ int Sagan_Xbit_Type ( char *type, int linecount, const char *ruleset )
         return(4);
     }
 
-    Sagan_Log(S_ERROR, "[%s, line %d] Expected 'none', 'both', by_src', 'by_dst' or 'reverse'.  Got '%s' at line %d.", __FILE__, __LINE__, type, linecount, ruleset);
+    if (!strcmp(type, "src_xbitdst")) {
+        return(5);
+    }
+
+    if (!strcmp(type, "dst_xbitsrc")) {
+        return(6);
+    }
+
+    if (!strcmp(type, "both_p")) {
+        return(7);
+    }
+
+    if (!strcmp(type, "by_src_p")) {
+        return(8);
+    }
+
+    if (!strcmp(type, "by_dst_p")) {
+        return(9);
+    }
+
+    if (!strcmp(type, "reverse_p")) {
+        return(10);
+    }
+
+    if (!strcmp(type, "src_xbitdst_p")) {
+        return(11);
+    }
+
+    if (!strcmp(type, "dst_xbitsrc_p")) {
+        return(12);
+    }
+
+    Sagan_Log(S_ERROR, "[%s, line %d] Expected 'none', 'both', by_src', 'by_dst', 'reverse', 'src_xbitdst', 'dst_xbitsrc','both_p', by_src_p', 'by_dst_p', 'reverse_p', 'src_xbitdst_p', or 'dst_xbitsrc_p'.  Got '%s' at line %d.", __FILE__, __LINE__, type, linecount, ruleset);
 
     return(0); 	/* Should never make it here */
 

--- a/src/xbit.c
+++ b/src/xbit.c
@@ -232,8 +232,8 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                         if ( rulestruct[rule_position].xbit_direction[i] == 7 &&
                              xbit_ipc[a].ip_src == ip_src &&
                              xbit_ipc[a].ip_dst == ip_dst &&
-							 xbit_ipc[a].src_port == src_port &&
-							 xbit_ipc[a].dst_port == dst_port )
+                             xbit_ipc[a].src_port == src_port &&
+                             xbit_ipc[a].dst_port == dst_port )
 
                         {
 
@@ -250,7 +250,7 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
 
                         if ( rulestruct[rule_position].xbit_direction[i] == 8 &&
                              xbit_ipc[a].ip_src == ip_src &&
-							 xbit_ipc[a].src_port == src_port )
+                             xbit_ipc[a].src_port == src_port )
 
                         {
 
@@ -267,7 +267,7 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
 
                         if ( rulestruct[rule_position].xbit_direction[i] == 9 &&
                              xbit_ipc[a].ip_dst == ip_dst &&
-							 xbit_ipc[a].dst_port == dst_port )
+                             xbit_ipc[a].dst_port == dst_port )
 
                         {
 
@@ -285,8 +285,8 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                         if ( rulestruct[rule_position].xbit_direction[i] == 10 &&
                              xbit_ipc[a].ip_src == ip_dst &&
                              xbit_ipc[a].ip_dst == ip_src &&
-							 xbit_ipc[a].src_port == dst_port &&
-							 xbit_ipc[a].dst_port == src_port )
+                             xbit_ipc[a].src_port == dst_port &&
+                             xbit_ipc[a].dst_port == src_port )
 
                         {
                             if ( debug->debugxbit) {
@@ -302,7 +302,7 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
 
                         if ( rulestruct[rule_position].xbit_direction[i] == 11 &&
                              xbit_ipc[a].ip_dst == ip_src &&
-							 xbit_ipc[a].dst_port == src_port )
+                             xbit_ipc[a].dst_port == src_port )
 
                         {
 
@@ -319,7 +319,7 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
 
                         if ( rulestruct[rule_position].xbit_direction[i] == 12 &&
                              xbit_ipc[a].ip_src == ip_dst &&
-							 xbit_ipc[a].src_port == dst_port )
+                             xbit_ipc[a].src_port == dst_port )
 
                         {
 
@@ -494,8 +494,8 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
 
                                 if ( xbit_ipc[a].ip_src == ip_src &&
                                      xbit_ipc[a].ip_dst == ip_dst &&
-									 xbit_ipc[a].src_port == src_port &&
-									 xbit_ipc[a].dst_port == dst_port ) {
+                                     xbit_ipc[a].src_port == src_port &&
+                                     xbit_ipc[a].dst_port == dst_port ) {
 
                                     if ( debug->debugxbit) {
                                         Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"both_y\"). (%s -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char, ip_dst_char);
@@ -512,7 +512,7 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                             if ( rulestruct[rule_position].xbit_direction[i] == 8 ) {
 
                                 if ( xbit_ipc[a].ip_src == ip_src &&
-           							 xbit_ipc[a].src_port == src_port ) {
+                                     xbit_ipc[a].src_port == src_port ) {
 
                                     if ( debug->debugxbit) {
                                         Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"by_src_p\"). (%s -> any)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char);
@@ -529,7 +529,7 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                             if ( rulestruct[rule_position].xbit_direction[i] == 9 ) {
 
                                 if ( xbit_ipc[a].ip_dst == ip_dst &&
-           							 xbit_ipc[a].dst_port == dst_port ) {
+                                     xbit_ipc[a].dst_port == dst_port ) {
 
                                     if ( debug->debugxbit) {
                                         Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"by_dst_p\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char);
@@ -547,8 +547,8 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
 
                                 if ( xbit_ipc[a].ip_src == ip_dst &&
                                      xbit_ipc[a].ip_dst == ip_src &&
-									 xbit_ipc[a].src_port == dst_port &&
-									 xbit_ipc[a].dst_port == src_port) {
+                                     xbit_ipc[a].src_port == dst_port &&
+                                     xbit_ipc[a].dst_port == src_port) {
 
                                     if ( debug->debugxbit) {
                                         Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"reverse_p\"). (%s -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char, ip_src_char);
@@ -565,7 +565,7 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                             if ( rulestruct[rule_position].xbit_direction[i] == 11 ) {
 
                                 if ( xbit_ipc[a].ip_dst == ip_src &&
-           							 xbit_ipc[a].dst_port == src_port ) {
+                                     xbit_ipc[a].dst_port == src_port ) {
 
                                     if ( debug->debugxbit) {
                                         Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"src_xbitdst_p\"). (%s -> any)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char);
@@ -582,7 +582,7 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                             if ( rulestruct[rule_position].xbit_direction[i] == 12 ) {
 
                                 if ( xbit_ipc[a].ip_src == ip_dst &&
-           							 xbit_ipc[a].src_port == dst_port ) {
+                                     xbit_ipc[a].src_port == dst_port ) {
 
                                     if ( debug->debugxbit) {
                                         Sagan_Log(S_DEBUG, "[%s, line %d] \"isnotset\" xbit \"%s\" (direction: \"dst_xbitsrc_p\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char);
@@ -947,8 +947,8 @@ void Sagan_Xbit_Set(int rule_position, char *ip_src_char, char *ip_dst_char, int
                         if ( rulestruct[rule_position].xbit_direction[i] == 10 &&
                              xbit_ipc[a].ip_dst == ip_src &&
                              xbit_ipc[a].ip_src == ip_dst &&
-							 xbit_ipc[a].src_port == dst_port &&
-							 xbit_ipc[a].dst_port == src_port )
+                             xbit_ipc[a].src_port == dst_port &&
+                             xbit_ipc[a].dst_port == src_port )
 
                         {
 
@@ -972,7 +972,7 @@ void Sagan_Xbit_Set(int rule_position, char *ip_src_char, char *ip_dst_char, int
 
                         if ( rulestruct[rule_position].xbit_direction[i] == 11 &&
                              xbit_ipc[a].ip_dst == ip_src &&
-							 xbit_ipc[a].dst_port == src_port ) {
+                             xbit_ipc[a].dst_port == src_port ) {
 
                             if ( debug->debugxbit) {
                                 Sagan_Log(S_DEBUG, "[%s, line %d] \"unset\" xbit \"%s\" (direction: \"src_xbitdst_p\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_src_char);
@@ -994,7 +994,7 @@ void Sagan_Xbit_Set(int rule_position, char *ip_src_char, char *ip_dst_char, int
 
                         if ( rulestruct[rule_position].xbit_direction[i] == 12 &&
                              xbit_ipc[a].ip_src == ip_dst &&
-							 xbit_ipc[a].src_port == dst_port ) {
+                             xbit_ipc[a].src_port == dst_port ) {
 
                             if ( debug->debugxbit) {
                                 Sagan_Log(S_DEBUG, "[%s, line %d] \"unset\" xbit \"%s\" (direction: \"dst_xbitsrc_p\"). (any -> %s)", __FILE__, __LINE__, xbit_ipc[a].xbit_name, ip_dst_char);

--- a/src/xbit.h
+++ b/src/xbit.h
@@ -22,8 +22,8 @@
 #include "config.h"             /* From autoconf */
 #endif
 
-void Sagan_Xbit_Set( int, char *, char * );
-int Sagan_Xbit_Condition ( int, char *, char * );
+void Sagan_Xbit_Set( int, char *, char *, int, int );
+int Sagan_Xbit_Condition ( int, char *, char *, int, int );
 int Sagan_Xbit_Type ( char *, int, const char *);
 void Sagan_Xbit_Cleanup(void);
 
@@ -31,6 +31,8 @@ typedef struct _Sagan_Xbit_Track _Sagan_Xbit_Track;
 struct _Sagan_Xbit_Track {
     char	xbit_name[64];
     int		xbit_timeout;
+    int		xbit_srcport;
+    int		xbit_dstport;
 };
 
 
@@ -41,6 +43,8 @@ struct _Sagan_IPC_Xbit {
     sbool xbit_state;
     uint32_t ip_src;
     uint32_t ip_dst;
+    int src_port;
+	int dst_port;
     char username[64];
     uintmax_t xbit_date;
     uintmax_t xbit_expire;

--- a/tools/sagan-peek.c
+++ b/tools/sagan-peek.c
@@ -422,9 +422,9 @@ int main(int argc, char **argv)
     if ( counters_ipc->xbit_count >= 1 ) {
 
         printf("\n*** Xbits (%d) ****\n", counters_ipc->xbit_count);
-        printf("-----------------------------------------------------------------------------------------------------------------------------\n");
-        printf("%-9s| %-25s| %-16s| %-16s| %-21s| %s\n", "S", "Xbit name", "SRC IP", "DST IP", "Date added/modified", "Expire");
-        printf("-----------------------------------------------------------------------------------------------------------------------------\n");
+        printf("----------------------------------------------------------------------------------------------------------------------------------------------\n");
+        printf("%-9s| %-25s| %-16s| %-16s| %-8s| %-8s| %-21s| %s\n", "S", "Xbit name", "SRC IP", "DST IP", "SRC PRT", "DST PRT", "Date added/modified", "Expire");
+        printf("----------------------------------------------------------------------------------------------------------------------------------------------\n");
 
         for ( i = 0; i < counters_ipc->xbit_count; i++) {
 
@@ -440,6 +440,8 @@ int main(int argc, char **argv)
 
             printf("%-16s| ", inet_ntoa(ip_addr_src));
             printf("%-16s| ", inet_ntoa(ip_addr_dst));
+            printf("%-8d| ", xbit_ipc[i].src_port);
+            printf("%-8d| ", xbit_ipc[i].dst_port);
             printf("%-21s| ", u32_time_to_human(xbit_ipc[i].xbit_date));
             printf("%d (%s)\n", xbit_ipc[i].expire, u32_time_to_human(xbit_ipc[i].xbit_date + xbit_ipc[i].expire));
 


### PR DESCRIPTION
1. Added two additional ways of tracking xbits that are essentially one-sided reverse operations (event src IP to xbit dst IP, event dst IP to xbit src IP).
          - I use this for things like detecting callbacks after a potentially malicious download where the cnc server is not necessarily the source of the download.
2. Expanded the definition of an xbit to store source and destination port. Expanded matching logic to enable matching by IP and port.
          - I needed this to refine the correlation of events for a particular application on one or more hosts.
3. Updated the Sagan-peek tool to show the added xbit fields
          - Edited this neat (undocumented?) tool to look into xbits in the ipc directory
4. Added three new ways of setting an xbit to work with #2 above
          - Simply adding all port pairs is quite wasteful because of unimportant ephemeral ports
          - By default, set adds the default port for src and destination
          - Three other set operations add the relevant source port, destination port, or both