### PR TITLE
Flow checking for ports and protocol with support for port variables

### DIFF
--- a/src/check-flow.c
+++ b/src/check-flow.c
@@ -45,7 +45,7 @@ struct _Rule_Struct *rulestruct;
 /* 3 = match ip     */ /************************/ /*****************/
 /********************/ /************************/ /*****************/
 
-sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, uint32_t ip_dst_u32)
+sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, int normalize_src_port, uint32_t ip_dst_u32, int normalize_dst_port)
 {
 
     uint32_t *src;
@@ -54,15 +54,22 @@ sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, uint32_t ip_dst_u32)
     uint32_t ip_src;
     uint32_t ip_dst;
 
+    int port_src;
+	int port_dst;
+
     src = &ip_src_u32;
     dst = &ip_dst_u32;
 
     if(rulestruct[b].direction == 0 || rulestruct[b].direction == 1) {
         ip_src = *src;
         ip_dst = *dst;
+        port_src = normalize_src_port;
+        port_dst = normalize_dst_port;
     } else {
         ip_src = *dst;
         ip_dst = *src;
+        port_src = normalize_dst_port;
+        port_dst = normalize_src_port;
     }
 
     /*flow 1*/
@@ -78,6 +85,9 @@ sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, uint32_t ip_dst_u32)
 //    char tmp_flow_1[512];
     int f1;
 
+    /*port 1*/
+    int b1=0;
+
     /*flow 2*/
     int z=0;
     int a2=0;
@@ -90,6 +100,9 @@ sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, uint32_t ip_dst_u32)
 //    char *tmp2;
 //    char tmp_flow_2[512];
     int f2;
+
+    /*port 2*/
+    int b2=0;
 
 //    uint32_t lo;
 //    uint32_t hi;
@@ -150,6 +163,19 @@ sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, uint32_t ip_dst_u32)
         }
     }
 
+    /*Begin port_1*/
+    if(rulestruct[b].port_1_var != 0) {
+        if(port_src == rulestruct[b].src_port) {
+            b1=1;
+    	}
+    } else {
+        b1=1;
+    }
+
+    if(b1 != 1) {
+        return 0;
+    }
+
     /*Begin flow_2*/
     if(rulestruct[b].flow_2_var != 0) {
         for(i=0; i < rulestruct[b].flow_2_counter + 1; i++) {
@@ -201,6 +227,19 @@ sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, uint32_t ip_dst_u32)
         if(failed > 0) {
             return 0;
         }
+    }
+
+    /*Begin port_2*/
+    if(rulestruct[b].port_2_var != 0) {
+        if(port_dst == rulestruct[b].dst_port) {
+            b2=1;
+    	}
+    } else {
+        b2=1;
+    }
+
+    if(b2 != 1) {
+        return 0;
     }
 
     /* If we made it to this point we have a match */

--- a/src/check-flow.c
+++ b/src/check-flow.c
@@ -45,7 +45,7 @@ struct _Rule_Struct *rulestruct;
 /* 3 = match ip     */ /************************/ /*****************/
 /********************/ /************************/ /*****************/
 
-sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, int normalize_src_port, uint32_t ip_dst_u32, int normalize_dst_port)
+sbool Sagan_Check_Flow( int b, int ip_proto, uint32_t ip_src_u32, int normalize_src_port, uint32_t ip_dst_u32, int normalize_dst_port)
 {
 
     uint32_t *src;
@@ -71,6 +71,9 @@ sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, int normalize_src_port, uint
         port_src = normalize_dst_port;
         port_dst = normalize_src_port;
     }
+
+    /*proto*/
+    int c1=0;
 
     /*flow 1*/
     int w=0;
@@ -109,6 +112,19 @@ sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, int normalize_src_port, uint
 
     int i;
     int failed=0;
+
+    /*Begin ip_proto*/
+    if(rulestruct[b].ip_proto != 0) {
+        if(ip_proto == rulestruct[b].ip_proto) {
+            c1=1;
+    	}
+    } else {
+        c1=1;
+    }
+
+    if(c1 != 1) {
+        return 0;
+    }
 
     /*Begin flow_1*/
     if(rulestruct[b].flow_1_var != 0) {

--- a/src/check-flow.c
+++ b/src/check-flow.c
@@ -94,6 +94,13 @@ sbool Check_Flow( int b, int ip_proto, uint32_t ip_src_u32, int normalize_src_po
 
     /*port 1*/
     int b1=0;
+    int u=0;
+    int eq3=0;
+    int ne3=0;
+    int eq3_val=0;
+    int ne3_val=0;
+    int g1;
+
 
     /*flow 2*/
     int z=0;
@@ -110,6 +117,12 @@ sbool Check_Flow( int b, int ip_proto, uint32_t ip_src_u32, int normalize_src_po
 
     /*port 2*/
     int b2=0;
+    int v=0;
+    int eq4=0;
+    int ne4=0;
+    int eq4_val=0;
+    int ne4_val=0;
+    int g2;
 
 //    uint32_t lo;
 //    uint32_t hi;
@@ -127,7 +140,7 @@ sbool Check_Flow( int b, int ip_proto, uint32_t ip_src_u32, int normalize_src_po
         }
     else
         {
-        c1=1;
+            c1=1;
         }
 
     if(c1 != 1)
@@ -212,9 +225,46 @@ sbool Check_Flow( int b, int ip_proto, uint32_t ip_src_u32, int normalize_src_po
     /*Begin port_1*/
     if(rulestruct[b].port_1_var != 0)
         {
-            if(port_src == rulestruct[b].src_port)
+            for(i=0; i < rulestruct[b].port_1_counter; i++)       //originally port_1_counter + 1. Deleted +1.
                 {
-                    b1=1;
+                    u++;
+                    g1 = rulestruct[b].port_1_type[u];
+
+                    if(g1 == 0)
+                        {
+                            ne3++;
+                            if(port_src >= rulestruct[b].port_1[i].lo && port_src <= rulestruct[b].port_1[i].hi)
+                                {
+                                    ne3_val++;
+                                }
+                        }
+
+                    if(g1 == 1)
+                        {
+                            eq3++;
+                            if(port_src >= rulestruct[b].port_1[i].lo && port_src <= rulestruct[b].port_1[i].hi)
+                                {
+                                    eq3_val++;
+                                }
+                        }
+
+                    if(g1 == 2)
+                        {
+                            ne3++;
+                            if(port_src == rulestruct[b].port_1[i].lo)
+                                {
+                                    ne3_val++;
+                                }
+                        }
+
+                    if(g1 == 3)
+                        {
+                            eq3++;
+                            if(port_src == rulestruct[b].port_1[i].lo)
+                                {
+                                    eq3_val++;
+                                }
+                        }
                 }
         }
     else
@@ -222,10 +272,34 @@ sbool Check_Flow( int b, int ip_proto, uint32_t ip_src_u32, int normalize_src_po
             b1=1;
         }
 
+    /* if ne3, did anything match (meaning failed) */
+    if(ne3>0)
+        {
+            if(ne3_val > 0)
+                {
+                    failed++;
+                }
+        }
+
+    /* if eq3, did anything not match meaning failed */
+    if(eq3>0)
+        {
+            if(eq3_val < 1)
+                {
+                    failed++;
+                }
+        }
+
+    /* if either failed, we did not match, no need to check the second flow... we already failed! */
     if(b1 != 1)
         {
-            return 0;
+            if(failed > 0)
+                {
+                    return 0;
+                }
         }
+
+
 
     /*Begin flow_2*/
     if(rulestruct[b].flow_2_var != 0)
@@ -304,9 +378,46 @@ sbool Check_Flow( int b, int ip_proto, uint32_t ip_src_u32, int normalize_src_po
     /*Begin port_2*/
     if(rulestruct[b].port_2_var != 0)
         {
-            if(port_dst == rulestruct[b].dst_port)
+            for(i=0; i < rulestruct[b].port_2_counter; i++)       //originally port_2_counter + 1. Deleted +1.
                 {
-                    b2=1;
+                    v++;
+                    g2 = rulestruct[b].port_2_type[v];
+
+                    if(g2 == 0)
+                        {
+                            ne4++;
+                            if(port_dst >= rulestruct[b].port_2[i].lo && port_dst <= rulestruct[b].port_2[i].hi)
+                                {
+                                    ne4_val++;
+                                }
+                        }
+
+                    if(g2 == 1)
+                        {
+                            eq4++;
+                            if(port_dst >= rulestruct[b].port_2[i].lo && port_dst <= rulestruct[b].port_2[i].hi)
+                                {
+                                    eq4_val++;
+                                }
+                        }
+
+                    if(g2 == 2)
+                        {
+                            ne4++;
+                            if(port_dst == rulestruct[b].port_2[i].lo)
+                                {
+                                    ne4_val++;
+                                }
+                        }
+
+                    if(g2 == 3)
+                        {
+                            eq4++;
+                            if(port_dst == rulestruct[b].port_2[i].lo)
+                                {
+                                    eq4_val++;
+                                }
+                        }
                 }
         }
     else
@@ -314,9 +425,31 @@ sbool Check_Flow( int b, int ip_proto, uint32_t ip_src_u32, int normalize_src_po
             b2=1;
         }
 
+    /* if ne4, did anything match (meaning failed) */
+    if(ne4>0)
+        {
+            if(ne4_val > 0)
+                {
+                    failed++;
+                }
+        }
+
+    /* if eq4, did anything not match meaning failed */
+    if(eq4>0)
+        {
+            if(eq4_val < 1)
+                {
+                    failed++;
+                }
+        }
+
+    /* if either failed, we did not match, no need to check the second flow... we already failed! */
     if(b2 != 1)
         {
-            return 0;
+            if(failed > 0)
+                {
+                    return 0;
+                }
         }
 
     /* If we made it to this point we have a match */

--- a/src/check-flow.c
+++ b/src/check-flow.c
@@ -225,7 +225,7 @@ sbool Check_Flow( int b, int ip_proto, uint32_t ip_src_u32, int normalize_src_po
     /*Begin port_1*/
     if(rulestruct[b].port_1_var != 0)
         {
-            for(i=0; i < rulestruct[b].port_1_counter; i++)       //originally port_1_counter + 1. Deleted +1.
+            for(i=0; i < rulestruct[b].port_1_counter; i++)
                 {
                     u++;
                     g1 = rulestruct[b].port_1_type[u];
@@ -378,7 +378,7 @@ sbool Check_Flow( int b, int ip_proto, uint32_t ip_src_u32, int normalize_src_po
     /*Begin port_2*/
     if(rulestruct[b].port_2_var != 0)
         {
-            for(i=0; i < rulestruct[b].port_2_counter; i++)       //originally port_2_counter + 1. Deleted +1.
+            for(i=0; i < rulestruct[b].port_2_counter; i++)
                 {
                     v++;
                     g2 = rulestruct[b].port_2_type[v];

--- a/src/check-flow.c
+++ b/src/check-flow.c
@@ -55,7 +55,7 @@ sbool Check_Flow( int b, int ip_proto, uint32_t ip_src_u32, int normalize_src_po
     uint32_t ip_dst;
 
     int port_src;
-	int port_dst;
+    int port_dst;
 
     src = &ip_src_u32;
     dst = &ip_dst_u32;

--- a/src/check-flow.h
+++ b/src/check-flow.h
@@ -22,4 +22,4 @@
 #include "config.h"             /* From autoconf */
 #endif
 
-sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, uint32_t ip_dst_u32);
+sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, int normalize_src_port, uint32_t ip_dst_u32, int normalize_dst_port);

--- a/src/check-flow.h
+++ b/src/check-flow.h
@@ -22,4 +22,4 @@
 #include "config.h"             /* From autoconf */
 #endif
 
-sbool Sagan_Check_Flow( int b, uint32_t ip_src_u32, int normalize_src_port, uint32_t ip_dst_u32, int normalize_dst_port);
+sbool Sagan_Check_Flow( int b, int ip_proto, uint32_t ip_src_u32, int normalize_src_port, uint32_t ip_dst_u32, int normalize_dst_port);

--- a/src/processors/engine.c
+++ b/src/processors/engine.c
@@ -693,17 +693,17 @@ int Sagan_Engine ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, sbool dynamic_rule
                     ip_src_u32 = IP2Bit(ip_src);
                     ip_dst_u32 = IP2Bit(ip_dst);
 
-                    ip_dstport_u32 = normalize_dst_port;
                     ip_srcport_u32 = normalize_src_port;
+                    ip_dstport_u32 = normalize_dst_port;
 
                     strlcpy(s_msg, rulestruct[b].s_msg, sizeof(s_msg));
 
                     /* Check for flow of rule - has_flow is set as rule loading.  It 1, then
-                    the rule has some sort of flow.  It 0,  rule is set any/any */
+                    the rule has some sort of flow.  It 0,  rule is set any:any/any:any */
 
                     if ( rulestruct[b].has_flow == 1 ) {
 
-                        check_flow_return = Sagan_Check_Flow( b, ip_src_u32, ip_dst_u32);
+                        check_flow_return = Sagan_Check_Flow( b, ip_src_u32, normalize_src_port, ip_dst_u32, normalize_dst_port);
 
                         if(check_flow_return == false) {
 

--- a/src/processors/engine.c
+++ b/src/processors/engine.c
@@ -643,12 +643,10 @@ int Sagan_Engine ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, sbool dynamic_rule
 
                     /* If the rule calls for proto searching,  we do it now */
 
-//                    proto = 0;
-
-                    proto = rulestruct[b].default_proto;
+                    proto = 0;
 
                     if ( rulestruct[b].s_find_proto_program == 1 ) {
-//                        proto = Sagan_Parse_Proto_Program(SaganProcSyslog_LOCAL->syslog_program);
+                        proto = Sagan_Parse_Proto_Program(SaganProcSyslog_LOCAL->syslog_program);
                     }
 
                     if ( rulestruct[b].s_find_proto == 1 && proto == 0 ) {
@@ -658,9 +656,9 @@ int Sagan_Engine ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, sbool dynamic_rule
                     /* If proto is not searched or has failed,  default to whatever the rule told us to
                        use */
 
-//                    if ( proto == 0 ) {
-//                        proto = rulestruct[b].default_proto;
-//                    }
+                    if ( proto == 0 ) {
+                        proto = rulestruct[b].default_proto;
+                    }
 
                     if ( ip_src_flag == 0 || ip_src[0] == '0' ) {
                         strlcpy(ip_src, SaganProcSyslog_LOCAL->syslog_host, sizeof(ip_src));
@@ -709,12 +707,12 @@ int Sagan_Engine ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, sbool dynamic_rule
 
                     strlcpy(s_msg, rulestruct[b].s_msg, sizeof(s_msg));
 
-                    /* Check for flow of rule - has_flow is set as rule loading.  It 1, then
-                    the rule has some sort of flow.  It 0,  rule is set any:any/any:any */
+                    /* Check for flow of rule - has_flow is set as rule loading.  If 1, then
+                    the rule has some sort of flow.  If 0,  rule is set any:any/any:any */
 
                     if ( rulestruct[b].has_flow == 1 ) {
 
-                        check_flow_return = Sagan_Check_Flow( b, ip_src_u32, normalize_src_port, ip_dst_u32, normalize_dst_port);
+                        check_flow_return = Sagan_Check_Flow( b, proto, ip_src_u32, normalize_src_port, ip_dst_u32, normalize_dst_port);
 
                         if(check_flow_return == false) {
 

--- a/src/processors/engine.c
+++ b/src/processors/engine.c
@@ -208,7 +208,8 @@ int Sagan_Engine ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, sbool dynamic_rule
     sbool thresh_flag = false;
     sbool thresh_log_flag = false;
 
-    int proto = config->sagan_proto;		/* Set proto to default */
+//    int proto = config->sagan_proto;		/* Set proto to default */
+    int proto = 0;
 
     sbool brointel_results = 0;
     sbool blacklist_results = 0;
@@ -642,10 +643,12 @@ int Sagan_Engine ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, sbool dynamic_rule
 
                     /* If the rule calls for proto searching,  we do it now */
 
-                    proto = 0;
+//                    proto = 0;
+
+                    proto = rulestruct[b].default_proto;
 
                     if ( rulestruct[b].s_find_proto_program == 1 ) {
-                        proto = Sagan_Parse_Proto_Program(SaganProcSyslog_LOCAL->syslog_program);
+//                        proto = Sagan_Parse_Proto_Program(SaganProcSyslog_LOCAL->syslog_program);
                     }
 
                     if ( rulestruct[b].s_find_proto == 1 && proto == 0 ) {
@@ -655,9 +658,9 @@ int Sagan_Engine ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, sbool dynamic_rule
                     /* If proto is not searched or has failed,  default to whatever the rule told us to
                        use */
 
-                    if ( proto == 0 ) {
-                        proto = rulestruct[b].ip_proto;
-                    }
+//                    if ( proto == 0 ) {
+//                        proto = rulestruct[b].default_proto;
+//                    }
 
                     if ( ip_src_flag == 0 || ip_src[0] == '0' ) {
                         strlcpy(ip_src, SaganProcSyslog_LOCAL->syslog_host, sizeof(ip_src));
@@ -668,11 +671,19 @@ int Sagan_Engine ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, sbool dynamic_rule
                     }
 
                     if ( normalize_src_port == 0 ) {
+                        normalize_src_port=rulestruct[b].default_src_port;
+                    }
+
+                    if ( normalize_src_port == 0 ) {
                         normalize_src_port=config->sagan_port;
                     }
 
                     if ( normalize_dst_port == 0 ) {
-                        normalize_dst_port=rulestruct[b].dst_port;
+                        normalize_dst_port=rulestruct[b].default_dst_port;
+                    }
+
+                    if ( normalize_dst_port == 0 ) {
+                        normalize_dst_port=config->sagan_port;
                     }
 
                     if ( proto == 0 ) {

--- a/src/rules.c
+++ b/src/rules.c
@@ -252,6 +252,10 @@ void Load_Rules( const char *ruleset )
 
         rc=0;
 
+        if (!Sagan_strstr(rulebuf, "any")) {
+            rc++;
+        }
+
         if (!Sagan_strstr(rulebuf, "tcp")) {
             rc++;
         }
@@ -268,8 +272,8 @@ void Load_Rules( const char *ruleset )
             rc++;
         }
 
-        if ( rc == 4 ) {
-            Sagan_Log(S_ERROR, "[%s, line %d] %s on line %d appears to not have a protocol type (tcp/udp/icmp/syslog)", __FILE__, __LINE__, ruleset_fullname, linecount);
+        if ( rc == 5 ) {
+            Sagan_Log(S_ERROR, "[%s, line %d] %s on line %d appears to not have a protocol type (any/tcp/udp/icmp/syslog)", __FILE__, __LINE__, ruleset_fullname, linecount);
         }
 
         /* Parse forward for the first '(' */
@@ -334,11 +338,15 @@ void Load_Rules( const char *ruleset )
 
             /* Protocol */
 	
-	    ip_proto = config->sagan_proto;
+//	        ip_proto = config->sagan_proto;
 
             if ( netcount == 1 ) {
 
                 //ip_proto = config->sagan_proto;
+
+            	if (!strcmp(tokennet, "any" )) {
+                    ip_proto = 0;
+                }
 
                 if (!strcmp(tokennet, "icmp" )) {
                     ip_proto = 1;
@@ -350,6 +358,10 @@ void Load_Rules( const char *ruleset )
 
                 if (!strcmp(tokennet, "udp"  )) {
                     ip_proto = 17;
+                }
+
+                if (!strcmp(tokennet, "syslog"  )) {
+                    ip_proto = config->sagan_proto;
                 }
             }
 
@@ -525,7 +537,7 @@ void Load_Rules( const char *ruleset )
                 rulestruct[counters->rulecount].dst_port = dst_port;	/* Set for the rule */
             }
 
-            if ( rulestruct[counters->rulecount].flow_1_var != 0 || rulestruct[counters->rulecount].port_1_var != 0 || rulestruct[counters->rulecount].flow_2_var != 0 || rulestruct[counters->rulecount].port_2_var != 0) {
+            if ( rulestruct[counters->rulecount].ip_proto != 0 || rulestruct[counters->rulecount].flow_1_var != 0 || rulestruct[counters->rulecount].port_1_var != 0 || rulestruct[counters->rulecount].flow_2_var != 0 || rulestruct[counters->rulecount].port_2_var != 0) {
                 rulestruct[counters->rulecount].has_flow = 1;
             }
 
@@ -2076,6 +2088,9 @@ void Load_Rules( const char *ruleset )
             Sagan_Log(S_DEBUG, "= pri: %d", rulestruct[counters->rulecount].s_pri);
             Sagan_Log(S_DEBUG, "= classtype: %s", rulestruct[counters->rulecount].s_classtype);
             Sagan_Log(S_DEBUG, "= drop: %d", rulestruct[counters->rulecount].drop);
+            Sagan_Log(S_DEBUG, "= default_dst_port: %d", rulestruct[counters->rulecount].default_dst_port);
+            Sagan_Log(S_DEBUG, "= protocol: %d", rulestruct[counters->rulecount].ip_proto);
+            Sagan_Log(S_DEBUG, "= src_port: %d", rulestruct[counters->rulecount].src_port);
             Sagan_Log(S_DEBUG, "= dst_port: %d", rulestruct[counters->rulecount].dst_port);
 
             if ( rulestruct[counters->rulecount].s_find_src_ip != 0 ) {

--- a/src/rules.c
+++ b/src/rules.c
@@ -2668,7 +2668,7 @@ void Load_Rules( const char *ruleset )
                     Sagan_Log(S_DEBUG, "= pri: %d", rulestruct[counters->rulecount].s_pri);
                     Sagan_Log(S_DEBUG, "= classtype: %s", rulestruct[counters->rulecount].s_classtype);
                     Sagan_Log(S_DEBUG, "= drop: %d", rulestruct[counters->rulecount].drop);
-                    Sagan_Log(S_DEBUG, "= dst_port: %d", rulestruct[counters->rulecount].dst_port);
+                    Sagan_Log(S_DEBUG, "= default_dst_port: %d", rulestruct[counters->rulecount].default_dst_port);
 
                     if ( rulestruct[counters->rulecount].s_find_src_ip != 0 )
                         {

--- a/src/rules.c
+++ b/src/rules.c
@@ -412,18 +412,19 @@ void Load_Rules( const char *ruleset )
 
                 //src_port = config->sagan_port;                            /* Set to default */
 
-                if (strcmp(nettmp, "any")) {
-                    src_port = atoi(nettmp);       /* If it's _NOT_ "any", set to default */
+                if (!strcmp(nettmp, "any")) {
+                    rulestruct[counters->rulecount].port_1_var = 0;	  /* 0 = any */
                 }
+                else {
+                  rulestruct[counters->rulecount].port_1_var = 1;	  /* 1 = var */
+                  if (Is_Numeric(nettmp)) {
+                      src_port = atoi(nettmp);          /* If it's a number (see Sagan_Var_To_Value),  then set to that */
+                  }
 
-                if (Is_Numeric(nettmp)) {
-                    src_port = atoi(nettmp);          /* If it's a number (see Sagan_Var_To_Value),  then set to that */
+                  if ( src_port == 0 ) {
+                      Sagan_Log(S_ERROR, "[%s, line %d] Invalid source port on line %d in %s", __FILE__, __LINE__, linecount, ruleset_fullname);
+                  }
                 }
-
-                if ( src_port == 0 ) {
-                    Sagan_Log(S_ERROR, "[%s, line %d] Invalid source port on line %d in %s", __FILE__, __LINE__, linecount, ruleset_fullname);
-                }
-
                 rulestruct[counters->rulecount].src_port = src_port;      /* Set for the rule */
             }
 
@@ -497,13 +498,6 @@ void Load_Rules( const char *ruleset )
                 }
             }
 
-            /* Used later for a single check to determine if a rule has a flow or not
-               - Champ Clark III (06/12/2016) */
-
-            if ( rulestruct[counters->rulecount].flow_1_var != 0 || rulestruct[counters->rulecount].flow_2_var != 0 ) {
-                rulestruct[counters->rulecount].has_flow = 1;
-            }
-
 	    dst_port = config->sagan_port;                          /* Set to default */
 
             /* Destination Port */
@@ -511,21 +505,25 @@ void Load_Rules( const char *ruleset )
 
                 //dst_port = config->sagan_port;				/* Set to default */
 
-                if (strcmp(nettmp, "any")) {
-                    dst_port = atoi(nettmp);	/* If it's _NOT_ "any", set to default */
+                if (!strcmp(nettmp, "any")) {
+                	rulestruct[counters->rulecount].port_2_var = 0;	  /* 0 = any */
                 }
+                else {
+                  rulestruct[counters->rulecount].port_2_var = 1;	  /* 1 = var */
+                  if (Is_Numeric(nettmp)) {
+                      dst_port = atoi(nettmp);		/* If it's a number (see Sagan_Var_To_Value),  then set to that */
+                  }
 
-                if (Is_Numeric(nettmp)) {
-                    dst_port = atoi(nettmp);		/* If it's a number (see Sagan_Var_To_Value),  then set to that */
+                  if ( dst_port == 0 ) {
+                      Sagan_Log(S_ERROR, "[%s, line %d] Invalid destination port on line %d in %s", __FILE__, __LINE__, linecount, ruleset_fullname);
+                  }
                 }
-
-                if ( dst_port == 0 ) {
-                    Sagan_Log(S_ERROR, "[%s, line %d] Invalid destination port on line %d in %s", __FILE__, __LINE__, linecount, ruleset_fullname);
-                }
-
                 rulestruct[counters->rulecount].dst_port = dst_port;	/* Set for the rule */
             }
 
+            if ( rulestruct[counters->rulecount].flow_1_var != 0 || rulestruct[counters->rulecount].port_1_var != 0 || rulestruct[counters->rulecount].flow_2_var != 0 || rulestruct[counters->rulecount].port_2_var != 0) {
+                rulestruct[counters->rulecount].has_flow = 1;
+            }
 
             tokennet = strtok_r(NULL, " ", &saveptrnet);
             nettmp = Sagan_Var_To_Value(tokennet); 			/* Convert $VAR to values per line */

--- a/src/rules.c
+++ b/src/rules.c
@@ -175,6 +175,10 @@ void Load_Rules( const char *ruleset )
     int dst_port=0;
     int src_port=0;
 
+    int default_proto=0;
+    int default_dst_port=0;
+    int default_src_port=0;
+
     /* Store rule set names/path in memory for later usage dynamic loading, etc */
 
     strlcpy(ruleset_fullname, ruleset, sizeof(ruleset_fullname));
@@ -405,7 +409,7 @@ void Load_Rules( const char *ruleset )
                 }
             }
 
-	    src_port = config->sagan_port;                            /* Set to default */
+//	    src_port = config->sagan_port;                            /* Set to default */
 
             /* Source Port */
             if ( netcount == 3 ) {
@@ -498,7 +502,7 @@ void Load_Rules( const char *ruleset )
                 }
             }
 
-	    dst_port = config->sagan_port;                          /* Set to default */
+//	    dst_port = config->sagan_port;                          /* Set to default */
 
             /* Destination Port */
             if ( netcount == 6 ) {
@@ -570,22 +574,23 @@ void Load_Rules( const char *ruleset )
 			Sagan_Log(S_ERROR, "[%s, line %d] The \"default_proto\" option appears to be incomplete at line %d in %s", __FILE__, __LINE__, linecount, ruleset_fullname);
 		} 
 
-		Remove_Spaces(Sagan_Var_To_Value(arg)); 
+		arg = Remove_Spaces(Sagan_Var_To_Value(arg));
 
 		if (!strcmp(arg, "icmp") || !strcmp(arg, "1")) {
-			rulestruct[counters->rulecount].ip_proto = 1; 
+			rulestruct[counters->rulecount].default_proto = 1;
 		} 
 
 		else if (!strcmp(arg, "tcp" ) || !strcmp(arg, "6" )) {
-			rulestruct[counters->rulecount].ip_proto = 6; 
+			rulestruct[counters->rulecount].default_proto = 6;
 		} 
 
 		else if (!strcmp(arg, "udp" ) || !strcmp(arg, "17" )) {
-			rulestruct[counters->rulecount].ip_proto = 17;
+			rulestruct[counters->rulecount].default_proto = 17;
 		}
 	
 	    }
 
+	    default_src_port = config->sagan_port;
 	    if (!strcmp(rulesplit, "default_src_port")) {
 
 		arg = strtok_r(NULL, ":", &saveptrrule2);
@@ -597,11 +602,11 @@ void Load_Rules( const char *ruleset )
 		Remove_Spaces(Sagan_Var_To_Value(arg));
 
 
-		rulestruct[counters->rulecount].src_port = atoi(arg); 
+		rulestruct[counters->rulecount].default_src_port = atoi(arg);
 
 	    }
 
-	
+            default_dst_port = config->sagan_port;
             if (!strcmp(rulesplit, "default_dst_port")) {
                 
                 arg = strtok_r(NULL, ":", &saveptrrule2);
@@ -613,7 +618,7 @@ void Load_Rules( const char *ruleset )
                 Remove_Spaces(Sagan_Var_To_Value(arg));
             
             
-                rulestruct[counters->rulecount].dst_port = atoi(arg);
+                rulestruct[counters->rulecount].default_dst_port = atoi(arg);
             
             }
 

--- a/src/rules.h
+++ b/src/rules.h
@@ -85,6 +85,8 @@ struct _Rule_Struct {
 
     sbool flow_1_var;
     sbool flow_2_var;
+    sbool port_1_var;
+    sbool port_2_var;
 
     sbool has_flow;
 
@@ -92,6 +94,7 @@ struct _Rule_Struct {
     int flow_2_type[MAX_CHECK_FLOWS];
     int  flow_1_counter;
     int  flow_2_counter;
+
 
     sbool s_nocase[MAX_CONTENT];
     int s_offset[MAX_CONTENT];

--- a/src/rules.h
+++ b/src/rules.h
@@ -127,9 +127,14 @@ struct _Rule_Struct {
     char xbit_name[MAX_XBITS][64];              /* Name of the xbit */
 
     int ref_count;
-    int dst_port;
-    int src_port;
-    int ip_proto;
+    int dst_port;                               /*dst port to match against events*/
+    int src_port;                               /*src port to match against events*/
+    int ip_proto;                               /*protocol to match against events*/
+
+    int default_dst_port;                       /*default dst port to set*/
+    int default_src_port;                       /*default src port to set*/
+    int default_proto;                          /*default protocol to set*/
+
     sbool s_find_port;
     sbool s_find_proto;
     sbool s_find_proto_program;

--- a/src/rules.h
+++ b/src/rules.h
@@ -153,8 +153,6 @@ struct _Rule_Struct
     char xbit_name[MAX_XBITS][64];              /* Name of the xbit */
 
     int ref_count;
-    int dst_port;                               /*dst port to match against events*/
-//    int src_port;                               /*src port to match against events*/
     int ip_proto;                               /*protocol to match against events*/
 
     int default_dst_port;                       /*default dst port to set*/

--- a/src/rules.h
+++ b/src/rules.h
@@ -46,6 +46,20 @@ struct arr_flow_2
     uint32_t hi;
 };
 
+typedef struct arr_port_1 arr_port_1;
+struct arr_port_1
+{
+    int lo;
+    int hi;
+};
+
+typedef struct arr_port_2 arr_port_2;
+struct arr_port_2
+{
+    int lo;
+    int hi;
+};
+
 typedef struct meta_content_conversion meta_content_conversion;
 struct meta_content_conversion
 {
@@ -84,6 +98,9 @@ struct _Rule_Struct
     struct arr_flow_1 flow_1[MAX_CHECK_FLOWS];
     struct arr_flow_2 flow_2[MAX_CHECK_FLOWS];
 
+    struct arr_port_1 port_1[MAX_CHECK_FLOWS];
+    struct arr_port_2 port_2[MAX_CHECK_FLOWS];
+
     struct meta_content_conversion meta_content_containers[MAX_META_CONTENT];
 
     int direction;
@@ -97,9 +114,13 @@ struct _Rule_Struct
 
     int flow_1_type[MAX_CHECK_FLOWS];
     int flow_2_type[MAX_CHECK_FLOWS];
-    int  flow_1_counter;
-    int  flow_2_counter;
+    int flow_1_counter;
+    int flow_2_counter;
 
+    int port_1_type[MAX_CHECK_FLOWS];
+    int port_2_type[MAX_CHECK_FLOWS];
+    int port_1_counter;
+    int port_2_counter;
 
     sbool s_nocase[MAX_CONTENT];
     int s_offset[MAX_CONTENT];
@@ -133,7 +154,7 @@ struct _Rule_Struct
 
     int ref_count;
     int dst_port;                               /*dst port to match against events*/
-    int src_port;                               /*src port to match against events*/
+//    int src_port;                               /*src port to match against events*/
     int ip_proto;                               /*protocol to match against events*/
 
     int default_dst_port;                       /*default dst port to set*/

--- a/src/xbit.c
+++ b/src/xbit.c
@@ -315,7 +315,7 @@ int Sagan_Xbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char
                             break;
                         }
 
-                        /* direction: dst_xbitsrc */
+                        /* direction: dst_xbitsrc_p */
 
                         if ( rulestruct[rule_position].xbit_direction[i] == 12 &&
                              xbit_ipc[a].ip_src == ip_dst &&


### PR DESCRIPTION
This implements the changes discussed in Issue #84 

Protocol and Ports at the beginning of each rule are now fields that are checked against messages.

Default protocol and default port options in each rule provide the function previously held by the protocol and ports at the beginning of the rule.

Port ranges and groups are supported in rules and in sagan.yaml in a similar way to port groups in Snort. For example, 
         IRC_PORTS: "6660-6669,7000" 
is a valid port-group entry in sagan.yaml.

The attached test files may help in testing/review.
[SaganYamlPorts.txt](https://github.com/beave/sagan/files/921152/SaganYamlPorts.txt)
[portcheck.txt](https://github.com/beave/sagan/files/921153/portcheck.txt)
[portcheckrules.txt](https://github.com/beave/sagan/files/921154/portcheckrules.txt)


