### PR TITLE
Fixroutingdotc

### DIFF
--- a/src/routing.c
+++ b/src/routing.c
@@ -94,11 +94,13 @@ bool Sagan_Check_Routing(  _Sagan_Routing *SaganRouting )
                                                                                 }
                                                                         }
 #else
+
                                                                 ret = true;
 #endif
                                                                 }
                                                         }
 #ifdef HAVE_LIBMAXMINDDB
+
                                                 }
 #endif
                                         }

--- a/src/routing.c
+++ b/src/routing.c
@@ -87,16 +87,20 @@ bool Sagan_Check_Routing(  _Sagan_Routing *SaganRouting )
                                                                                             if ( config->bluedot_flag == false || rulestruct[SaganRouting->position].bluedot_ipaddr_type == false || ( rulestruct[SaganRouting->position].bluedot_ipaddr_type != 0 && SaganRouting->bluedot_ip_flag == true ))
                                                                                                 {
 
-#endif
                                                                                                     ret = true;
 
                                                                                                 }
                                                                                         }
                                                                                 }
                                                                         }
+#else
+                                                                ret = true;
+#endif
                                                                 }
                                                         }
+#ifdef HAVE_LIBMAXMINDDB
                                                 }
+#endif
                                         }
                                 }
                         }


### PR DESCRIPTION
This refers to issue #132 regarding routing.c not compiling.  In a series of nested if statements the closing braces were not commented out by the #ifdef statements but the opening braces were.  This fix just takes care of that without changing any program flow.