### PR TITLE
Do not wipe rule conditions like syslog_facility, syslog_level etc

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -2071,9 +2071,6 @@ void Load_Rules( const char *ruleset )
                             rulestruct[counters->rulecount].s_sid = atol(arg);
                         }
 
-
-                    rulestruct[counters->rulecount].s_tag[0] = '\0';
-
                     if (!strcmp(rulesplit, "syslog_tag" ))
                         {
                             arg = strtok_r(NULL, ":", &saveptrrule2);
@@ -2088,9 +2085,6 @@ void Load_Rules( const char *ruleset )
                             Remove_Spaces(arg);
                             strlcpy(rulestruct[counters->rulecount].s_tag, arg, sizeof(rulestruct[counters->rulecount].s_tag));
                         }
-
-
-                    rulestruct[counters->rulecount].s_facility[0] = '\0';
 
                     if (!strcmp(rulesplit, "syslog_facility" ))
                         {
@@ -2107,8 +2101,6 @@ void Load_Rules( const char *ruleset )
                             strlcpy(rulestruct[counters->rulecount].s_facility, arg, sizeof(rulestruct[counters->rulecount].s_facility));
                         }
 
-                    rulestruct[counters->rulecount].s_level[0] = '\0';
-
                     if (!strcmp(rulesplit, "syslog_level" ))
                         {
                             arg = strtok_r(NULL, ":", &saveptrrule2);
@@ -2123,8 +2115,6 @@ void Load_Rules( const char *ruleset )
                             Remove_Spaces(arg);
                             strlcpy(rulestruct[counters->rulecount].s_level, arg, sizeof(rulestruct[counters->rulecount].s_level));
                         }
-
-                    rulestruct[counters->rulecount].s_syspri[0] = '\0';
 
                     if (!strcmp(rulesplit, "syslog_priority" ))
                         {


### PR DESCRIPTION
Fixes #141

The problem was that all these settings were being zeroed every time around the loop.  Since they are already zeroed by [memset](https://github.com/beave/sagan/blob/master/src/rules.c#L271)  I don't think any further initialization is required.