### PR TITLE
Improve syslog_tag handling

### DIFF
--- a/src/processors/engine.c
+++ b/src/processors/engine.c
@@ -182,7 +182,7 @@ int Sagan_Engine ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, bool dynamic_rule_
     uint32_t ip_dstport_u32 = 0;
     unsigned char ip_dst_bits[MAXIPBIT] = { 0 };
 
-    char tmpbuf[128] = { 0 };
+    char tmpbuf[256] = { 0 };
     char s_msg[1024] = { 0 };
    
     char syslog_append_program[MAX_SYSLOGMSG] = { 0 };

--- a/src/rules.c
+++ b/src/rules.c
@@ -2281,10 +2281,25 @@ void Load_Rules( const char *ruleset )
 
                             if (arg == NULL )
                                 {
-                                    Sagan_Log(ERROR, "[%s, line %d] The \"tag\" appears to be incomplete at line %d in %s, Abort", __FILE__, __LINE__, linecount, ruleset_fullname);
+                                    Sagan_Log(ERROR, "[%s, line %d] The \"syslog_tag\" appears to be incomplete at line %d in %s, Abort", __FILE__, __LINE__, linecount, ruleset_fullname);
+                                }
+                            Remove_Spaces(arg);
+                            if (strlen(arg) > MAX_SYSLOG_TAG_SIZE)
+                            {
+                              Sagan_Log(ERROR, "[%s, line %d] The complete \"syslog_tag\" appears to be exceeding the max length at line %d in %s, Abort", __FILE__, __LINE__, linecount, ruleset_fullname);  
+                            }
+                            
+                            ptmp = strtok_r(arg, "|", &tok);
+                            while ( ptmp != NULL )
+                                {
+                                    if (strlen(ptmp) > MAX_SYSLOG_TAG)
+                                        {
+                                            Sagan_Log(ERROR, "[%s, line %d] The individual \"syslog_tag\" appears to be exceeding the max length at line %d in %s, Abort", __FILE__, __LINE__, linecount, ruleset_fullname);
+                                        }
+
+                                    ptmp = strtok_r(NULL, "|", &tok);
                                 }
 
-                            Remove_Spaces(arg);
                             strlcpy(rulestruct[counters->rulecount].s_tag, arg, sizeof(rulestruct[counters->rulecount].s_tag));
                         }
 

--- a/src/rules.h
+++ b/src/rules.h
@@ -103,7 +103,7 @@ struct _Rule_Struct
     char s_facility[50];
     char s_syspri[25];
     char s_level[25];
-    char s_tag[10];
+    char s_tag[MAX_SYSLOG_TAG_SIZE];
 
     char event_id[MAX_EVENT_ID][32];
 

--- a/src/sagan-defs.h
+++ b/src/sagan-defs.h
@@ -94,9 +94,10 @@ typedef void json_object;
 #define MAXTAG			32		/* Max syslog 'tag' length */
 #define MAXLEVEL		15		/* Max syslog 'level' length */
 
-#define MAX_SAGAN_MSG		256		/* Max "msg" option size */
+#define MAX_SAGAN_MSG		 256		/* Max "msg" option size */
 
-#define MAX_PCRE_SIZE		1024		/* Max pcre length in a rule */
+#define MAX_PCRE_SIZE		 1024		/* Max pcre length in a rule */
+#define MAX_SYSLOG_TAG_SIZE 256     /* Max syslog_tag length in a rule */
 
 #define MAX_FIFO_SIZE		1048576		/* Max pipe/FIFO size in bytes/pages */
 


### PR DESCRIPTION
Related to Issue: Inconsistent max syslog_tag length settings and tmpbuf length #157

Please let me know if this is an acceptable solution.

Best regards,

Stef