### PR TITLE
Doc: Add missing slash to pipe field in rsyslog's configuration

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -48,7 +48,7 @@ Example ``rsyslog`` "pipe" configuration, can be installed as
        constant(value="\n")
    }
    
-   *.*  action(type="ompipe" pipe="var/sagan/fifo/sagan.fifo" template="SaganPipe")
+   *.*  action(type="ompipe" pipe="/var/sagan/fifo/sagan.fifo" template="SaganPipe")
 
 NOTE: rsyslog's "msg" property includes
 `the space after the colon <https://www.rsyslog.com/log-normalization-and-the-leading-space/>`_.


### PR DESCRIPTION
Small fix for configuration in `/etc/rsyslog.d/10-sagan.conf`.