### PR TITLE
Fixes to allow building with gcc 10

### DIFF
--- a/src/aetas.c
+++ b/src/aetas.c
@@ -43,7 +43,7 @@
 #include "aetas.h"
 #include "rules.h"
 
-struct _Rule_Struct *rulestruct;
+extern struct _Rule_Struct *rulestruct;
 
 int Check_Time(int rule_number)
 {

--- a/src/after.c
+++ b/src/after.c
@@ -39,14 +39,14 @@
 
 pthread_mutex_t After2_Mutex=PTHREAD_MUTEX_INITIALIZER;
 
-struct _After2_IPC *After2_IPC;
+extern struct _After2_IPC *After2_IPC;
 
-struct _SaganCounters *counters;
-struct _Rule_Struct *rulestruct;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
 
-struct _Sagan_IPC_Counters *counters_ipc;
+extern struct _Sagan_IPC_Counters *counters_ipc;
 
 bool After2 ( int rule_position, char *ip_src, uint32_t src_port, char *ip_dst,  uint32_t dst_port, char *username, char *syslog_message )
 {

--- a/src/classifications.c
+++ b/src/classifications.c
@@ -43,10 +43,10 @@
 #include "gen-msg.h"
 #include "classifications.h"
 
-struct _SaganCounters *counters;
-struct _Class_Struct *classstruct;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _Class_Struct *classstruct;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
 
 void Load_Classifications( const char *ruleset )
 {

--- a/src/config-yaml.c
+++ b/src/config-yaml.c
@@ -67,7 +67,7 @@
 #include "processors/bluedot.h"
 
 bool bluedot_load;
-struct _Sagan_Bluedot_Skip *Bluedot_Skip;
+extern struct _Sagan_Bluedot_Skip *Bluedot_Skip;
 
 #endif
 
@@ -75,8 +75,8 @@ struct _Sagan_Bluedot_Skip *Bluedot_Skip;
 
 #include <liblognorm.h>
 #include "liblognormalize.h"
-struct liblognorm_struct *liblognormstruct;
-int liblognorm_count;
+extern struct liblognorm_struct *liblognormstruct;
+extern int liblognorm_count;
 
 #endif
 
@@ -87,18 +87,18 @@ struct _Sagan_GeoIP_Skip *GeoIP_Skip;
 
 #endif
 
-struct _SaganConfig *config;
-struct _SaganDebug *debug;
-struct _SaganVar *var;
-struct _SaganCounters *counters;
-struct _Rules_Loaded *rules_loaded;
-struct _Rule_Struct *rulestruct;
+extern struct _SaganConfig *config;
+extern struct _SaganDebug *debug;
+extern struct _SaganVar *var;
+extern struct _SaganCounters *counters;
+extern struct _Rules_Loaded *rules_loaded;
+extern struct _Rule_Struct *rulestruct;
 
 #ifndef HAVE_LIBYAML
 ** You must of LIBYAML installed! **
 #endif
 
-bool reload_rules;
+extern bool reload_rules;
 
 #ifdef HAVE_LIBYAML
 

--- a/src/content.c
+++ b/src/content.c
@@ -35,7 +35,7 @@
 
 #include "parsers/parsers.h"
 
-struct _Rule_Struct *rulestruct;
+extern struct _Rule_Struct *rulestruct;
 
 
 bool Content ( int rule_position, const char *syslog_message )

--- a/src/event-id.c
+++ b/src/event-id.c
@@ -56,8 +56,8 @@
 #include "config.h"             /* From autoconf */
 #endif
 
-struct _SaganCounters *counters;
-struct _Rule_Struct *rulestruct;
+extern struct _SaganCounters *counters;
+extern struct _Rule_Struct *rulestruct;
 
 bool Event_ID ( int position, _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL )
 {

--- a/src/flexbit-mmap.c
+++ b/src/flexbit-mmap.c
@@ -43,15 +43,15 @@
 #include "sagan-config.h"
 #include "parsers/parsers.h"
 
-struct _SaganCounters *counters;
-struct _Rule_Struct *rulestruct;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
 
 pthread_mutex_t Flexbit_Mutex=PTHREAD_MUTEX_INITIALIZER;
 
-struct _Sagan_IPC_Counters *counters_ipc;
-struct _Sagan_IPC_Flexbit *flexbit_ipc;
+extern struct _Sagan_IPC_Counters *counters_ipc;
+extern struct _Sagan_IPC_Flexbit *flexbit_ipc;
 
 /*****************************************************************************
  * Flexbit_Condition - Used for testing "isset" & "isnotset".  Full

--- a/src/flexbit.c
+++ b/src/flexbit.c
@@ -40,7 +40,7 @@
 #include "flexbit.h"
 #include "flexbit-mmap.h"
 
-struct _SaganConfig *config;
+extern struct _SaganConfig *config;
 
 bool Flexbit_Condition(int rule_position, char *ip_src_char, char *ip_dst_char, int src_port, int dst_port )
 {

--- a/src/flow.c
+++ b/src/flow.c
@@ -35,7 +35,7 @@
 #include "rules.h"
 #include "sagan-config.h"
 
-struct _Rule_Struct *rulestruct;
+extern struct _Rule_Struct *rulestruct;
 
 /********************/ /************************/ /*****************/
 /***** flow_type ****/ /******* flow_var *******/ /*** direction ***/

--- a/src/gen-msg.c
+++ b/src/gen-msg.c
@@ -37,10 +37,10 @@
 #include "sagan-defs.h"
 #include "gen-msg.h"
 
-struct _SaganCounters *counters;
-struct _Sagan_Processor_Generator *generator;
-struct _SaganConfig *config;
-struct _SaganDebug *debug;
+extern struct _SaganCounters *counters;
+extern struct _Sagan_Processor_Generator *generator;
+extern struct _SaganConfig *config;
+extern struct _SaganDebug *debug;
 
 void Load_Gen_Map( const char *genmap )
 {

--- a/src/geoip.c
+++ b/src/geoip.c
@@ -49,10 +49,10 @@
 #include "geoip.h"
 #include "sagan-config.h"
 
-struct _SaganConfig *config;
-struct _Rule_Struct *rulestruct;
-struct _SaganDebug *debug;
-struct _SaganCounters *counters;
+extern struct _SaganConfig *config;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganDebug *debug;
+extern struct _SaganCounters *counters;
 struct _Sagan_GeoIP_Skip *GeoIP_Skip;
 
 void Open_GeoIP2_Database( void )

--- a/src/ignore-list.c
+++ b/src/ignore-list.c
@@ -38,8 +38,8 @@
 #include "sagan-config.h"
 
 struct _Sagan_Ignorelist *SaganIgnorelist;
-struct _SaganCounters *counters;
-struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _SaganConfig *config;
 
 /****************************************************************************
  * "ignore" list.

--- a/src/input-json-map.c
+++ b/src/input-json-map.c
@@ -41,8 +41,8 @@ libfastjson is required for Sagan to function!
 #include "version.h"
 #include "input-pipe.h"
 
-struct _SaganConfig *config;
-struct _Syslog_JSON_Map *Syslog_JSON_Map;
+extern struct _SaganConfig *config;
+extern struct _Syslog_JSON_Map *Syslog_JSON_Map;
 
 void Load_Input_JSON_Map ( const char *json_map )
 {

--- a/src/input-json.c
+++ b/src/input-json.c
@@ -38,11 +38,11 @@
 
 #include "parsers/json.h"
 
-struct _SaganCounters *counters;
-struct _SaganConfig *config;
-struct _SaganDebug *debug;
+extern struct _SaganCounters *counters;
+extern struct _SaganConfig *config;
+extern struct _SaganDebug *debug;
 
-struct _Syslog_JSON_Map *Syslog_JSON_Map;
+extern struct _Syslog_JSON_Map *Syslog_JSON_Map;
 
 void SyslogInput_JSON( char *syslog_string, struct _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL )
 {

--- a/src/input-pipe.c
+++ b/src/input-pipe.c
@@ -33,10 +33,10 @@
 #include "version.h"
 #include "input-pipe.h"
 
-struct _SaganCounters *counters;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
-struct _SaganDNSCache *dnscache;
+extern struct _SaganCounters *counters;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
+extern struct _SaganDNSCache *dnscache;
 
 void SyslogInput_Pipe( char *syslog_string, struct _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL )
 {

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -56,12 +56,12 @@
 
 struct _Sagan_IPC_Counters *counters_ipc;
 
-struct _SaganConfig *config;
+extern struct _SaganConfig *config;
 
-pthread_mutex_t After2_Mutex;
-pthread_mutex_t Thresh2_Mutex;
-pthread_mutex_t Flexbit_Mutex;
-pthread_mutex_t Xbit_Mutex;
+extern pthread_mutex_t After2_Mutex;
+extern pthread_mutex_t Thresh2_Mutex;
+extern pthread_mutex_t Flexbit_Mutex;
+extern pthread_mutex_t Xbit_Mutex;
 
 struct _After2_IPC *After2_IPC;
 struct _Threshold2_IPC *Threshold2_IPC;
@@ -69,7 +69,7 @@ struct _Sagan_Track_Clients_IPC *SaganTrackClients_ipc;
 struct _Sagan_IPC_Flexbit *flexbit_ipc;
 struct _Sagan_IPC_Xbit *Xbit_IPC;
 
-struct _SaganDebug *debug;
+extern struct _SaganDebug *debug;
 
 /*****************************************************************************
  * Clean_IPC_Object - If the max IPC is hit,  we attempt to "clean" out

--- a/src/json-content.c
+++ b/src/json-content.c
@@ -37,7 +37,7 @@
 
 #include "parsers/parsers.h"
 
-struct _Rule_Struct *rulestruct;
+extern struct _Rule_Struct *rulestruct;
 
 bool JSON_Content(int rule_position, _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL)
 {

--- a/src/json-handler.c
+++ b/src/json-handler.c
@@ -44,9 +44,9 @@
 #include "sagan-config.h"
 #include "json-handler.h"
 
-struct _SaganConfig *config;
-struct _SaganDebug *debug;
-struct _Rule_Struct *rulestruct;
+extern struct _SaganConfig *config;
+extern struct _SaganDebug *debug;
+extern struct _Rule_Struct *rulestruct;
 
 /*****************************************************************************
  * Format_JSON_Alert_EVE - Sends only alerts out to eve file in JSON

--- a/src/json-meta-content.c
+++ b/src/json-meta-content.c
@@ -28,7 +28,7 @@
 
 #include "parsers/parsers.h"
 
-struct _Rule_Struct *rulestruct;
+extern struct _Rule_Struct *rulestruct;
 
 bool JSON_Meta_Content(int rule_position, _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL)
 {

--- a/src/json-pcre.c
+++ b/src/json-pcre.c
@@ -35,7 +35,7 @@
 
 #include "parsers/parsers.h"
 
-struct _Rule_Struct *rulestruct;
+extern struct _Rule_Struct *rulestruct;
 
 bool JSON_Pcre(int rule_position, _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL)
 {

--- a/src/key.c
+++ b/src/key.c
@@ -47,7 +47,7 @@
 #include "key.h"
 #include "stats.h"
 
-struct _SaganConfig *config;
+extern struct _SaganConfig *config;
 
 void Key_Handler( void )
 {

--- a/src/liblognormalize.c
+++ b/src/liblognormalize.c
@@ -43,8 +43,8 @@
 #include "liblognormalize.h"
 #include "sagan-config.h"
 
-struct _SaganConfig *config;
-struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
+extern struct _SaganDebug *debug;
 
 struct _SaganNormalizeLiblognorm *SaganNormalizeLiblognorm = NULL;
 
@@ -58,7 +58,7 @@ int liblognorm_count;
 
 static ln_ctx ctx;
 
-struct _SaganCounters *counters;
+extern struct _SaganCounters *counters;
 
 
 /************************************************************************

--- a/src/lockfile.c
+++ b/src/lockfile.c
@@ -51,7 +51,7 @@
 
 #include "version.h"
 
-struct _SaganConfig *config;
+extern struct _SaganConfig *config;
 
 
 /* Was using liblockfile but decided for portability reasons, it was a

--- a/src/message-json-map.c
+++ b/src/message-json-map.c
@@ -46,11 +46,11 @@ libfastjson is required for Sagan to function!
 #include "parsers/json.h"
 
 
-struct _SaganConfig *config;
-struct _SaganCounters *counters;
-struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _SaganDebug *debug;
 
-struct _JSON_Message_Map *JSON_Message_Map;
+extern struct _JSON_Message_Map *JSON_Message_Map;
 struct _JSON_Message_Tmp *JSON_Message_Tmp;
 
 /*************************

--- a/src/meta-content.c
+++ b/src/meta-content.c
@@ -44,7 +44,7 @@
 #include "rules.h"
 #include "parsers/parsers.h"
 
-struct _Rule_Struct *rulestruct;
+extern struct _Rule_Struct *rulestruct;
 
 bool Meta_Content(int rule_position, const char *syslog_message)
 {

--- a/src/output-plugins/alert.c
+++ b/src/output-plugins/alert.c
@@ -43,9 +43,9 @@
 #include "references.h"
 #include "sagan-config.h"
 
-struct _Rule_Struct *rulestruct;
-struct _SaganConfig *config;
-struct _SaganCounters *counters;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
 
 void Alert_File( _Sagan_Event *Event )
 {

--- a/src/output-plugins/esmtp.c
+++ b/src/output-plugins/esmtp.c
@@ -48,10 +48,10 @@
 #include "util-time.h"
 #include "version.h"
 
-struct _Rule_Struct *rulestruct;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
-struct _SaganCounters *counters;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
 
 int ESMTP_Thread ( _Sagan_Event *Event )
 {

--- a/src/output-plugins/eve.c
+++ b/src/output-plugins/eve.c
@@ -43,7 +43,7 @@
 
 #include "sagan-config.h"
 
-struct _SaganConfig *config;
+extern struct _SaganConfig *config;
 
 void Alert_JSON( _Sagan_Event *Event )
 {

--- a/src/output-plugins/external.c
+++ b/src/output-plugins/external.c
@@ -48,9 +48,9 @@
 #include "util-time.h"
 #include "output-plugins/external.h"
 
-struct _Rule_Struct *rulestruct;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
 
 pthread_mutex_t ext_mutex = PTHREAD_MUTEX_INITIALIZER;
 

--- a/src/output-plugins/fast.c
+++ b/src/output-plugins/fast.c
@@ -41,8 +41,8 @@
 
 #include "output-plugins/alert.h"
 
-struct _Rule_Struct *rulestruct;
-struct _SaganConfig *config;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganConfig *config;
 
 void Fast_File( _Sagan_Event *Event )
 {

--- a/src/output-plugins/syslog-handler.c
+++ b/src/output-plugins/syslog-handler.c
@@ -43,8 +43,8 @@
 
 #include "output-plugins/syslog-handler.h"
 
-struct _Rule_Struct *rulestruct;
-struct _SaganConfig *config;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganConfig *config;
 
 void Alert_Syslog( _Sagan_Event *Event )
 {

--- a/src/output.c
+++ b/src/output.c
@@ -49,9 +49,9 @@
 #include "output-plugins/esmtp.h"
 #endif
 
-struct _SaganCounters *counters;
-struct _Rule_Struct *rulestruct;
-struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganConfig *config;
 
 bool nonthread_alert_lock = false;
 

--- a/src/parsers/hash.c
+++ b/src/parsers/hash.c
@@ -37,7 +37,7 @@
 #include "sagan-config.h"
 #include "parsers/parsers.h"
 
-struct _SaganConfig *config;
+extern struct _SaganConfig *config;
 
 void Parse_Hash(char *syslog_message, int type, char *str, size_t size)
 {

--- a/src/parsers/ip.c
+++ b/src/parsers/ip.c
@@ -82,8 +82,8 @@
 #include "version.h"
 #include "parsers/parsers.h"
 
-struct _SaganConfig *config;
-struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
+extern struct _SaganDebug *debug;
 
 int Parse_IP( char *syslog_message, struct _Sagan_Lookup_Cache_Entry *lookup_cache )
 {

--- a/src/parsers/json.c
+++ b/src/parsers/json.c
@@ -33,8 +33,8 @@
 #include "version.h"
 #include "debug.h"
 
-struct _SaganCounters *counters;
-struct _SaganDebug *debug;
+extern struct _SaganCounters *counters;
+extern struct _SaganDebug *debug;
 
 void Parse_JSON ( char *syslog_string, struct _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL )
 {

--- a/src/parsers/port.c
+++ b/src/parsers/port.c
@@ -51,7 +51,7 @@
 #include "sagan-config.h"
 #include "parsers/parsers.h"
 
-struct _SaganConfig *config;
+extern struct _SaganConfig *config;
 
 int Parse_Src_Port (char *msg)
 {

--- a/src/parsers/proto.c
+++ b/src/parsers/proto.c
@@ -38,8 +38,8 @@
 
 #include "protocol-map.h"
 
-struct _SaganConfig *config;
-struct _SaganCounters *counters;
+extern struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
 struct _Sagan_Protocol_Map_Message *map_message;
 struct _Sagan_Protocol_Map_Program *map_program;
 

--- a/src/pcre-s.c
+++ b/src/pcre-s.c
@@ -33,7 +33,7 @@
 #include "sagan-defs.h"
 #include "rules.h"
 
-struct _Rule_Struct *rulestruct;
+extern struct _Rule_Struct *rulestruct;
 
 
 bool PcreS ( int rule_position, const char *syslog_message )

--- a/src/plog.c
+++ b/src/plog.c
@@ -61,8 +61,8 @@
 #include "lockfile.h"
 #include "plog.h"
 
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
 
 struct my_udphdr
 {

--- a/src/processor.c
+++ b/src/processor.c
@@ -56,15 +56,15 @@
 #include "processors/dynamic-rules.h"
 #include "processors/client-stats.h"
 
-struct _SaganCounters *counters;
-struct _Sagan_Proc_Syslog *SaganProcSyslog;
-struct _Sagan_Pass_Syslog *SaganPassSyslog;
-struct _SaganConfig *config;
-struct _SaganDebug *debug;
+extern struct _SaganCounters *counters;
+extern struct _Sagan_Proc_Syslog *SaganProcSyslog;
+extern struct _Sagan_Pass_Syslog *SaganPassSyslog;
+extern struct _SaganConfig *config;
+extern struct _SaganDebug *debug;
 
 
-int proc_msgslot; 		/* Comes from sagan.c */
-int proc_running;   	        /* Comes from sagan.c */
+extern int proc_msgslot; 		/* Comes from sagan.c */
+extern int proc_running;   	        /* Comes from sagan.c */
 
 bool dynamic_rule_flag = NORMAL_RULE;
 uint32_t dynamic_line_count = 0;
@@ -72,13 +72,13 @@ uint32_t dynamic_line_count = 0;
 
 bool death=false;
 
-pthread_cond_t SaganProcDoWork;
-pthread_mutex_t SaganProcWorkMutex;
+extern pthread_cond_t SaganProcDoWork;
+extern pthread_mutex_t SaganProcWorkMutex;
 
-pthread_cond_t SaganReloadCond;
-pthread_mutex_t SaganReloadMutex;
+extern pthread_cond_t SaganReloadCond;
+extern pthread_mutex_t SaganReloadMutex;
 
-pthread_mutex_t SaganDynamicFlag;
+extern pthread_mutex_t SaganDynamicFlag;
 
 void Processor ( void )
 {

--- a/src/processors/blacklist.c
+++ b/src/processors/blacklist.c
@@ -45,9 +45,9 @@
 
 #include "processors/blacklist.h"
 
-struct _SaganCounters *counters;
-struct _SaganConfig *config;
-struct _SaganDebug *debug;
+extern struct _SaganCounters *counters;
+extern struct _SaganConfig *config;
+extern struct _SaganDebug *debug;
 struct _Sagan_Blacklist *SaganBlacklist;
 
 

--- a/src/processors/bluedot.c
+++ b/src/processors/bluedot.c
@@ -50,9 +50,9 @@
 
 #include "parsers/parsers.h"
 
-struct _SaganCounters *counters;
-struct _SaganConfig *config;
-struct _SaganDebug *debug;
+extern struct _SaganCounters *counters;
+extern struct _SaganConfig *config;
+extern struct _SaganDebug *debug;
 struct _Sagan_Bluedot_Skip *Bluedot_Skip;
 
 struct _Sagan_Bluedot_IP_Cache *SaganBluedotIPCache = NULL;
@@ -69,7 +69,7 @@ struct _Sagan_Bluedot_URL_Queue *SaganBluedotURLQueue = NULL;
 struct _Sagan_Bluedot_Filename_Queue *SaganBluedotFilenameQueue = NULL;
 struct _Sagan_Bluedot_JA3_Queue *SaganBluedotJA3Queue = NULL;
 
-struct _Rule_Struct *rulestruct;
+extern struct _Rule_Struct *rulestruct;
 
 pthread_mutex_t SaganProcBluedotWorkMutex=PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t CounterBluedotGenericMutex=PTHREAD_MUTEX_INITIALIZER;

--- a/src/processors/client-stats.c
+++ b/src/processors/client-stats.c
@@ -57,9 +57,9 @@
 
 uint64_t old_epoch = 0;
 
-struct _SaganConfig *config;
-struct _SaganCounters *counters;
-struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _SaganDebug *debug;
 
 struct _Client_Stats_Struct *Client_Stats = NULL;
 

--- a/src/processors/dynamic-rules.c
+++ b/src/processors/dynamic-rules.c
@@ -45,14 +45,14 @@
 
 #include "processors/dynamic-rules.h"
 
-struct _SaganConfig *config;
-struct _Rule_Struct *rulestruct;
+extern struct _SaganConfig *config;
+extern struct _Rule_Struct *rulestruct;
 struct _Rules_Loaded *rules_loaded;
-struct _SaganCounters *counters;
+extern struct _SaganCounters *counters;
 
 bool reload_rules;
 
-pthread_mutex_t SaganRulesLoadedMutex;
+pthread_mutex_t SaganRulesLoadedMutex=PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t CounterDynamicGenericMutex=PTHREAD_MUTEX_INITIALIZER;
 
 int Sagan_Dynamic_Rules ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, int rule_position, _Sagan_Processor_Info *processor_info_engine, char *ip_src, char *ip_dst )

--- a/src/processors/engine.c
+++ b/src/processors/engine.c
@@ -86,13 +86,13 @@
 
 #include "output-plugins/eve.h"
 
-struct _SaganCounters *counters;
-struct _Rule_Struct *rulestruct;
-struct _Sagan_Ruleset_Track *Ruleset_Track;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _Rule_Struct *rulestruct;
+extern struct _Sagan_Ruleset_Track *Ruleset_Track;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
 
-struct _Sagan_IPC_Counters *counters_ipc;
+extern struct _Sagan_IPC_Counters *counters_ipc;
 
 void Sagan_Engine_Init ( void )
 {

--- a/src/processors/perfmon.c
+++ b/src/processors/perfmon.c
@@ -48,9 +48,9 @@
 
 #include "processors/perfmon.h"
 
-struct _SaganConfig *config;
-struct _SaganCounters *counters;
-struct _Sagan_IPC_Counters *counters_ipc;
+extern struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _Sagan_IPC_Counters *counters_ipc;
 
 
 /*****************************************************************************

--- a/src/processors/stats-json.c
+++ b/src/processors/stats-json.c
@@ -57,9 +57,9 @@
 #include "util-time.h"
 #include "processors/stats-json.h"
 
-struct _SaganConfig *config;
-struct _SaganCounters *counters;
-struct _Sagan_IPC_Counters *counters_ipc;
+extern struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _Sagan_IPC_Counters *counters_ipc;
 
 void Stats_JSON_Init( void )
 {

--- a/src/processors/track-clients.c
+++ b/src/processors/track-clients.c
@@ -58,10 +58,10 @@ pthread_mutex_t IPCTrackClientsStatus=PTHREAD_MUTEX_INITIALIZER;
 
 struct _Sagan_Processor_Info *processor_info_track_client = NULL;
 struct _Sagan_Proc_Syslog *SaganProcSyslog;
-struct _Sagan_Track_Clients_IPC *SaganTrackClients_ipc;
-struct _Sagan_IPC_Counters *counters_ipc;
+extern struct _Sagan_Track_Clients_IPC *SaganTrackClients_ipc;
+extern struct _Sagan_IPC_Counters *counters_ipc;
 
-struct _SaganConfig *config;
+extern struct _SaganConfig *config;
 
 /****************************************************************************
  * Sagan_Track_Clients - Main routine to "tracks" via IPC/memory IPs that

--- a/src/processors/zeek-intel.c
+++ b/src/processors/zeek-intel.c
@@ -50,9 +50,9 @@
 
 #define MAX_BROINTEL_LINE_SIZE 10240
 
-struct _SaganConfig *config;
-struct _SaganCounters *counters;
-struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _SaganDebug *debug;
 
 struct _Sagan_Processor_Info *processor_info_brointel = NULL;
 

--- a/src/protocol-map.c
+++ b/src/protocol-map.c
@@ -36,11 +36,11 @@
 #include "sagan-defs.h"
 #include "protocol-map.h"
 
-struct _SaganCounters *counters;
-struct _SaganConfig *config;
-struct _SaganDebug *debug;
-struct _Sagan_Protocol_Map_Message *map_message;
-struct _Sagan_Protocol_Map_Program *map_program;
+extern struct _SaganCounters *counters;
+extern struct _SaganConfig *config;
+extern struct _SaganDebug *debug;
+extern struct _Sagan_Protocol_Map_Message *map_message;
+extern struct _Sagan_Protocol_Map_Program *map_program;
 
 void Load_Protocol_Map( const char *map )
 {

--- a/src/redis.c
+++ b/src/redis.c
@@ -42,8 +42,8 @@
 #include "lockfile.h"
 #include "redis.h"
 
-struct _SaganConfig *config;
-struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
+extern struct _SaganDebug *debug;
 
 int redis_msgslot = 0;
 

--- a/src/references.c
+++ b/src/references.c
@@ -41,12 +41,12 @@
 #include "references.h"
 #include "rules.h"
 
-struct _SaganCounters *counters;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
 
 struct _Ref_Struct *refstruct;
-struct _Rule_Struct *rulestruct;
+extern struct _Rule_Struct *rulestruct;
 
 void Load_Reference( const char *ruleset )
 {

--- a/src/routing.c
+++ b/src/routing.c
@@ -16,8 +16,8 @@
 #include "routing.h"
 #include "rules.h"
 
-struct _Rule_Struct *rulestruct;
-struct _SaganConfig *config;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganConfig *config;
 
 
 bool Sagan_Check_Routing(  _Sagan_Routing *SaganRouting )

--- a/src/rules.c
+++ b/src/rules.c
@@ -64,13 +64,13 @@
 #include <json.h>
 #endif
 
-struct _SaganCounters *counters;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
 
 #ifdef WITH_BLUEDOT
 
-struct _Sagan_Bluedot_Cat_List *SaganBluedotCatList;
+extern struct _Sagan_Bluedot_Cat_List *SaganBluedotCatList;
 
 char *bluedot_time = NULL;
 char *bluedot_type = NULL;
@@ -81,9 +81,9 @@ uint64_t bluedot_time_u32 = 0;
 
 #ifdef HAVE_LIBLOGNORM
 #include "liblognormalize.h"
-struct liblognorm_struct *liblognormstruct;
-struct liblognorm_toload_struct *liblognormtoloadstruct;
-int liblognorm_count;
+extern struct liblognorm_struct *liblognormstruct;
+extern struct liblognorm_toload_struct *liblognormtoloadstruct;
+extern int liblognorm_count;
 #endif
 
 /* For pre-8.20 PCRE compatibility */

--- a/src/sagan.c
+++ b/src/sagan.c
@@ -116,8 +116,8 @@ struct _JSON_Message_Map *JSON_Message_Map = NULL;
 
 /* Already Init'ed */
 
-struct _Rule_Struct *rulestruct;
-struct _Sagan_Ignorelist *SaganIgnorelist;
+extern struct _Rule_Struct *rulestruct;
+extern struct _Sagan_Ignorelist *SaganIgnorelist;
 
 #ifdef WITH_BLUEDOT
 #include "processors/bluedot.h"
@@ -137,7 +137,7 @@ int proc_running = 0;
 
 pthread_cond_t SaganProcDoWork=PTHREAD_COND_INITIALIZER;
 pthread_mutex_t SaganProcWorkMutex=PTHREAD_MUTEX_INITIALIZER;
-pthread_mutex_t SaganRulesLoadedMutex=PTHREAD_MUTEX_INITIALIZER;
+extern pthread_mutex_t SaganRulesLoadedMutex;
 
 /* ########################################################################
  * Start of main() thread

--- a/src/send-alert.c
+++ b/src/send-alert.c
@@ -37,7 +37,7 @@
 
 #include "processors/engine.h"
 
-struct _SaganConfig *config;
+extern struct _SaganConfig *config;
 
 void Send_Alert ( _Sagan_Proc_Syslog *SaganProcSyslog_LOCAL, char *json_normalize, _Sagan_Processor_Info *processor_info, char *ip_src, char *ip_dst, char *normalize_http_uri, char *normalize_http_hostname, int proto, uint64_t sid, int src_port, int dst_port, int pos, struct timeval tp, char *bluedot_json, unsigned char bluedot_results  )
 {

--- a/src/signal-handler.c
+++ b/src/signal-handler.c
@@ -70,52 +70,52 @@
 #ifdef HAVE_LIBLOGNORM
 #include "liblognormalize.h"
 #include <liblognorm.h>
-int liblognorm_count;
+extern int liblognorm_count;
 #endif
 
 #ifdef HAVE_LIBMAXMINDDB
 #include <maxminddb.h>
 #include "geoip.h"
-struct _Sagan_GeoIP_Skip *GeoIP_Skip;
+extern struct _Sagan_GeoIP_Skip *GeoIP_Skip;
 #endif
 
 #ifdef WITH_BLUEDOT
 #include "processors/bluedot.h"
-struct _Sagan_Bluedot_Skip *Bluedot_Skip;
+extern struct _Sagan_Bluedot_Skip *Bluedot_Skip;
 #endif
 
 #define MAX_DEATH_TIME 15
 
-struct _SaganCounters *counters;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
-struct _Rule_Struct *rulestruct;
-struct _Rules_Loaded *rules_loaded;
-struct _Class_Struct *classstruct;
-struct _Sagan_Processor_Generator *generator;
-struct _Sagan_Blacklist *SaganBlacklist;
+extern struct _SaganCounters *counters;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
+extern struct _Rule_Struct *rulestruct;
+extern struct _Rules_Loaded *rules_loaded;
+extern struct _Class_Struct *classstruct;
+extern struct _Sagan_Processor_Generator *generator;
+extern struct _Sagan_Blacklist *SaganBlacklist;
 struct _Sagan_Track_Clients *SaganTrackClients;
-struct _SaganVar *var;
+extern struct _SaganVar *var;
 
-struct _Sagan_Ignorelist *SaganIgnorelist;
+extern struct _Sagan_Ignorelist *SaganIgnorelist;
 
-struct _Sagan_BroIntel_Intel_Addr *Sagan_BroIntel_Intel_Addr;
-struct _Sagan_BroIntel_Intel_Domain *Sagan_BroIntel_Intel_Domain;
-struct _Sagan_BroIntel_Intel_File_Hash *Sagan_BroIntel_Intel_File_Hash;
-struct _Sagan_BroIntel_Intel_URL *Sagan_BroIntel_Intel_URL;
-struct _Sagan_BroIntel_Intel_Software *Sagan_BroIntel_Intel_Software;
-struct _Sagan_BroIntel_Intel_Email *Sagan_BroIntel_Intel_Email;
-struct _Sagan_BroIntel_Intel_User_Name *Sagan_BroIntel_Intel_User_Name;
-struct _Sagan_BroIntel_Intel_File_Name *Sagan_BroIntel_Intel_File_Name;
-struct _Sagan_BroIntel_Intel_Cert_Hash *Sagan_BroIntel_Intel_Cert_Hash;
+extern struct _Sagan_BroIntel_Intel_Addr *Sagan_BroIntel_Intel_Addr;
+extern struct _Sagan_BroIntel_Intel_Domain *Sagan_BroIntel_Intel_Domain;
+extern struct _Sagan_BroIntel_Intel_File_Hash *Sagan_BroIntel_Intel_File_Hash;
+extern struct _Sagan_BroIntel_Intel_URL *Sagan_BroIntel_Intel_URL;
+extern struct _Sagan_BroIntel_Intel_Software *Sagan_BroIntel_Intel_Software;
+extern struct _Sagan_BroIntel_Intel_Email *Sagan_BroIntel_Intel_Email;
+extern struct _Sagan_BroIntel_Intel_User_Name *Sagan_BroIntel_Intel_User_Name;
+extern struct _Sagan_BroIntel_Intel_File_Name *Sagan_BroIntel_Intel_File_Name;
+extern struct _Sagan_BroIntel_Intel_Cert_Hash *Sagan_BroIntel_Intel_Cert_Hash;
 
 pthread_mutex_t SaganReloadMutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t SaganReloadCond = PTHREAD_COND_INITIALIZER;
 
-pthread_mutex_t SaganRulesLoadedMutex;
+extern pthread_mutex_t SaganRulesLoadedMutex;
 
-bool death;
-int proc_running;
+extern bool death;
+extern int proc_running;
 
 void Sig_Handler( void )
 {

--- a/src/stats.c
+++ b/src/stats.c
@@ -44,12 +44,12 @@
 #include "processors/client-stats.h"
 
 
-struct _SaganCounters *counters;
-struct _Sagan_IPC_Counters *counters_ipc;
-struct _Sagan_Ruleset_Track *Ruleset_Track;
-struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _Sagan_IPC_Counters *counters_ipc;
+extern struct _Sagan_Ruleset_Track *Ruleset_Track;
+extern struct _SaganConfig *config;
 
-int proc_running; 	/* Count of executing threads */
+extern int proc_running; 	/* Count of executing threads */
 
 void Statistics( void )
 {

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -39,13 +39,13 @@
 
 pthread_mutex_t Thresh2_Mutex=PTHREAD_MUTEX_INITIALIZER;
 
-struct _Threshold2_IPC *Threshold2_IPC;
-struct _Sagan_IPC_Counters *counters_ipc;
+extern struct _Threshold2_IPC *Threshold2_IPC;
+extern struct _Sagan_IPC_Counters *counters_ipc;
 
-struct _SaganCounters *counters;
-struct _Rule_Struct *rulestruct;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
 
 /***********************/
 /* Threshold2          */

--- a/src/tracking-syslog.c
+++ b/src/tracking-syslog.c
@@ -55,9 +55,9 @@
 #include "rules.h"
 #include "tracking-syslog.h"
 
-struct _SaganConfig *config;
-struct _SaganCounters *counters;
-struct _Sagan_Ruleset_Track *Ruleset_Track;
+extern struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _Sagan_Ruleset_Track *Ruleset_Track;
 
 
 void RuleTracking_Syslog( void )

--- a/src/util.c
+++ b/src/util.c
@@ -59,8 +59,8 @@
 
 #include "version.h"
 
-struct _SaganConfig *config;
-struct _SaganCounters *counters;
+extern struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
 struct _SaganVar *var;
 struct _Sagan_Processor_Generator *generator;
 

--- a/src/xbit-mmap.c
+++ b/src/xbit-mmap.c
@@ -42,13 +42,13 @@
 #include "util-time.h"
 
 
-struct _SaganCounters *counters;
-struct _Rule_Struct *rulestruct;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
 
-struct _Sagan_IPC_Counters *counters_ipc;
-struct _Sagan_IPC_Xbit *Xbit_IPC;
+extern struct _Sagan_IPC_Counters *counters_ipc;
+extern struct _Sagan_IPC_Xbit *Xbit_IPC;
 
 pthread_mutex_t Xbit_Mutex=PTHREAD_MUTEX_INITIALIZER;
 

--- a/src/xbit-redis.c
+++ b/src/xbit-redis.c
@@ -44,10 +44,10 @@
 
 #define 	REDIS_PREFIX	"sagan"
 
-struct _SaganCounters *counters;
-struct _Rule_Struct *rulestruct;
-struct _SaganDebug *debug;
-struct _SaganConfig *config;
+extern struct _SaganCounters *counters;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganDebug *debug;
+extern struct _SaganConfig *config;
 
 struct _Sagan_Redis_Write *Sagan_Redis_Write;
 

--- a/src/xbit.c
+++ b/src/xbit.c
@@ -43,8 +43,8 @@
 
 #endif
 
-struct _Rule_Struct *rulestruct;
-struct _SaganConfig *config;
+extern struct _Rule_Struct *rulestruct;
+extern struct _SaganConfig *config;
 
 
 /***************************************************/

--- a/tools/saganpeek.c
+++ b/tools/saganpeek.c
@@ -140,12 +140,12 @@ int main(int argc, char **argv)
 
     int option_index = 0;
 
-    struct _Sagan_IPC_Counters *counters_ipc;
-    struct _Sagan_IPC_Flexbit *flexbit_ipc;
-    struct _Sagan_IPC_Xbit *xbit_ipc;
-    struct _Sagan_Track_Clients_IPC *SaganTrackClients_ipc;
-    struct _After2_IPC *After2_IPC;
-    struct _Threshold2_IPC *Threshold2_IPC;
+    extern struct _Sagan_IPC_Counters *counters_ipc;
+    extern struct _Sagan_IPC_Flexbit *flexbit_ipc;
+    extern struct _Sagan_IPC_Xbit *xbit_ipc;
+    extern struct _Sagan_Track_Clients_IPC *SaganTrackClients_ipc;
+    extern struct _After2_IPC *After2_IPC;
+    extern struct _Threshold2_IPC *Threshold2_IPC;
 
     signed char c;
 

--- a/tools/saganpeek.c
+++ b/tools/saganpeek.c
@@ -59,6 +59,13 @@
 #define TRACK_TYPE 4
 #define XBIT_TYPE 5
 
+/* Linking with ../util.o pulls in dependencies on these globals. Provide them here,
+ * even though they do not appear to be used by any code that is executed in this program. */
+#include "../src/sagan-config.h"
+struct _SaganConfig config;
+struct _SaganCounters counters;
+
+
 /****************************************************************************
  * usage - Give the user some hints about how to use this utility!
  ****************************************************************************/
@@ -140,12 +147,12 @@ int main(int argc, char **argv)
 
     int option_index = 0;
 
-    extern struct _Sagan_IPC_Counters *counters_ipc;
-    extern struct _Sagan_IPC_Flexbit *flexbit_ipc;
-    extern struct _Sagan_IPC_Xbit *xbit_ipc;
-    extern struct _Sagan_Track_Clients_IPC *SaganTrackClients_ipc;
-    extern struct _After2_IPC *After2_IPC;
-    extern struct _Threshold2_IPC *Threshold2_IPC;
+    struct _Sagan_IPC_Counters *counters_ipc;
+    struct _Sagan_IPC_Flexbit *flexbit_ipc;
+    struct _Sagan_IPC_Xbit *xbit_ipc;
+    struct _Sagan_Track_Clients_IPC *SaganTrackClients_ipc;
+    struct _After2_IPC *After2_IPC;
+    struct _Threshold2_IPC *Threshold2_IPC;
 
     signed char c;
 


### PR DESCRIPTION
When building with gcc 10.2.0, the build fails because of multiple
definitions of shared globals. Fix this by having one definition and
externs for all other occurrences. This is backwards compatible.